### PR TITLE
Ignore white space in comparison.

### DIFF
--- a/internal/system/system_linux.go
+++ b/internal/system/system_linux.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -98,7 +99,7 @@ func HasSecureRNG() bool {
 		return false
 	}
 	log.Printf("Have RNG: %s", haveRNG)
-	return string(haveRNG) == wantRNG
+	return strings.TrimSpace(string(haveRNG)) == wantRNG
 }
 
 // HasSecureKernelVersion checks if the system is running a kernel version that


### PR DESCRIPTION
The file rng_current ends with a newline, which breaks the overly strict string comparison.