### PR TITLE
Add `Builder` abstraction to simplify attestation.

### DIFF
--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -265,7 +265,7 @@ func TestAttestation(t *testing.T) {
 			require.NoError(t, err, errFromBody(t, resp))
 
 			// Ensure that the recovered nonce matches what we sent.
-			_, n, err := attestation.AuxFromServer(aux)
+			n, err := attestation.GetNonce(aux)
 			require.NoError(t, err)
 			require.Equal(t, c.nonce, n)
 		})
@@ -288,7 +288,7 @@ func TestHashes(t *testing.T) {
 			return testutil.Client.Get(intSrv("/enclave/hashes"))
 		}
 	)
-	hashes.SetAppHash(util.AddrOf([sha256.Size]byte{1}))
+	hashes.SetAppHash(util.AddrOf(sha256.Sum256([]byte("foo"))))
 
 	cases := []struct {
 		name       string
@@ -341,7 +341,7 @@ func TestHashes(t *testing.T) {
 			// Make sure that the application hashes match.
 			require.Equal(t, c.wantHashes.AppKeyHash, gotHashes.AppKeyHash)
 			// Make sure that the TLS certificate hash is set.
-			require.NotEmpty(t, gotHashes.TlsKeyHash)
+			require.NotEmpty(t, *gotHashes.TlsKeyHash)
 		})
 	}
 }

--- a/internal/enclave/attester.go
+++ b/internal/enclave/attester.go
@@ -9,7 +9,7 @@ import (
 const (
 	// See page 65 of the AWS Nitro Enclaves user guide for reference:
 	// https://docs.aws.amazon.com/pdfs/enclaves/latest/user/enclaves-user.pdf
-	userDataLen = 1024
+	AuxFieldLen = 1024
 	typeNoop    = "noop"
 	typeNitro   = "nitro"
 )
@@ -29,9 +29,9 @@ type AttestationDoc struct {
 }
 
 type AuxInfo struct {
-	PublicKey [userDataLen]byte `json:"workers_nonce"`
-	UserData  [userDataLen]byte `json:"leaders_nonce"`
-	Nonce     [userDataLen]byte `json:"public_key"`
+	PublicKey *[AuxFieldLen]byte `json:"public_key"`
+	UserData  *[AuxFieldLen]byte `json:"user_data"`
+	Nonce     *[AuxFieldLen]byte `json:"nonce"`
 }
 
 // Attester defines functions for the creation and verification of attestation

--- a/internal/enclave/attester_nitro.go
+++ b/internal/enclave/attester_nitro.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/nonce"
+	"github.com/Amnesic-Systems/veil/internal/util"
 
 	"github.com/hf/nitrite"
 	"github.com/hf/nsm"
@@ -88,8 +89,8 @@ func (a *NitroAttester) Verify(doc *AttestationDoc, ourNonce *nonce.Nonce) (_ *A
 	}
 
 	return &AuxInfo{
-		Nonce:     [userDataLen]byte(res.Document.Nonce),
-		UserData:  [userDataLen]byte(res.Document.UserData),
-		PublicKey: [userDataLen]byte(res.Document.PublicKey),
+		Nonce:     util.AddrOf([AuxFieldLen]byte(res.Document.Nonce)),
+		UserData:  util.AddrOf([AuxFieldLen]byte(res.Document.UserData)),
+		PublicKey: util.AddrOf([AuxFieldLen]byte(res.Document.PublicKey)),
 	}, nil
 }

--- a/internal/enclave/attester_nitro_test.go
+++ b/internal/enclave/attester_nitro_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getNonce(t *testing.T) [userDataLen]byte {
+func getNonce(t *testing.T) *[AuxFieldLen]byte {
 	n, err := nonce.New()
 	require.NoError(t, err)
 	return ToAuxField(n.ToSlice())

--- a/internal/enclave/attester_noop.go
+++ b/internal/enclave/attester_noop.go
@@ -18,6 +18,9 @@ func (*NoopAttester) Type() string {
 }
 
 func (*NoopAttester) Attest(aux *AuxInfo) (*AttestationDoc, error) {
+	// With the Nitro attester, the attestation document is a CBOR-encoded byte
+	// array.  For simplicity, the Noop attester encodes the given AuxInfo as a
+	// JSON object in the attestation document.
 	a, err := json.Marshal(aux)
 	if err != nil {
 		return nil, err
@@ -30,7 +33,7 @@ func (*NoopAttester) Attest(aux *AuxInfo) (*AttestationDoc, error) {
 
 func (*NoopAttester) Verify(a *AttestationDoc, n *nonce.Nonce) (*AuxInfo, error) {
 	var aux = new(AuxInfo)
-	if err := json.Unmarshal(a.Doc, &aux); err != nil {
+	if err := json.Unmarshal(a.Doc, aux); err != nil {
 		return nil, err
 	}
 	return aux, nil

--- a/internal/enclave/attester_noop_test.go
+++ b/internal/enclave/attester_noop_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Amnesic-Systems/veil/internal/nonce"
+	"github.com/Amnesic-Systems/veil/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,9 +16,9 @@ func TestSuccessfulVerification(t *testing.T) {
 	var (
 		a       = NewNoopAttester()
 		origAux = &AuxInfo{
-			PublicKey: [userDataLen]byte{'a', 'b', 'c'},
-			UserData:  [userDataLen]byte{'d', 'e', 'f'},
-			Nonce:     [userDataLen]byte{'g', 'h', 'i'},
+			PublicKey: util.AddrOf([AuxFieldLen]byte{'a', 'b', 'c'}),
+			UserData:  util.AddrOf([AuxFieldLen]byte{'d', 'e', 'f'}),
+			Nonce:     util.AddrOf([AuxFieldLen]byte{'g', 'h', 'i'}),
 		}
 	)
 

--- a/internal/enclave/pcr_test.go
+++ b/internal/enclave/pcr_test.go
@@ -15,10 +15,16 @@ func TestGetPCRs(t *testing.T) {
 	pcrs1, err := getPCRs()
 	require.NoError(t, err)
 
+	// PCRs for the enclave image file, the Linux kernel, and the application
+	// must always be set.
+	require.NotEmpty(t, pcrs1[0])
+	require.NotEmpty(t, pcrs1[1])
+	require.NotEmpty(t, pcrs1[2])
+
 	pcrs2, err := getPCRs()
 	require.NoError(t, err)
-
-	assert.False(t, pcrs1.Equal(pcrs2))
+	// PCRs should be the same across calls.
+	require.Equal(t, pcrs1, pcrs2)
 }
 
 func TestPCRsEqual(t *testing.T) {

--- a/internal/enclave/util.go
+++ b/internal/enclave/util.go
@@ -10,8 +10,8 @@ func IsEnclave() bool {
 	return false
 }
 
-func ToAuxField(s []byte) [userDataLen]byte {
-	var a [userDataLen]byte
+func ToAuxField(s []byte) *[AuxFieldLen]byte {
+	var a [AuxFieldLen]byte
 	copy(a[:], s)
-	return a
+	return &a
 }

--- a/internal/service/attestation/hashes.go
+++ b/internal/service/attestation/hashes.go
@@ -8,57 +8,80 @@ import (
 	"sync"
 
 	"github.com/Amnesic-Systems/veil/internal/errs"
+	"github.com/Amnesic-Systems/veil/internal/util"
 )
 
 // Hashes contains hashes over public key material which we embed in
 // the enclave's attestation document for clients to verify.
 type Hashes struct {
 	sync.Mutex
-	TlsKeyHash [sha256.Size]byte `json:"tls_key_hash"` // Always set.
-	AppKeyHash [sha256.Size]byte `json:"app_key_hash"` // Only set if the application has keys.
+	TlsKeyHash *[sha256.Size]byte `json:"tls_key_hash"` // Always set.
+	AppKeyHash *[sha256.Size]byte `json:"app_key_hash"` // Only set if the application has keys.
 }
 
 func (a *Hashes) SetAppHash(hash *[sha256.Size]byte) {
 	a.Lock()
 	defer a.Unlock()
 
-	a.AppKeyHash = *hash
+	a.AppKeyHash = hash
 }
 
 func (a *Hashes) SetTLSHash(hash *[sha256.Size]byte) {
 	a.Lock()
 	defer a.Unlock()
 
-	a.TlsKeyHash = *hash
+	a.TlsKeyHash = hash
 }
 
 func (a *Hashes) Serialize() []byte {
 	a.Lock()
 	defer a.Unlock()
 
-	b64TLSHash := base64.StdEncoding.EncodeToString(a.TlsKeyHash[:])
-	b64AppHash := base64.StdEncoding.EncodeToString(a.AppKeyHash[:])
-	str := fmt.Sprintf("sha256:%s;sha256:%s", b64TLSHash, b64AppHash)
+	str := fmt.Sprintf("sha256:%s;sha256:",
+		base64.StdEncoding.EncodeToString(a.TlsKeyHash[:]))
+	// The application's hash is optional.
+	if a.AppKeyHash != nil {
+		str += base64.StdEncoding.EncodeToString(a.AppKeyHash[:])
+	}
 	return []byte(str)
 }
 
 func DeserializeHashes(b []byte) (h *Hashes, err error) {
 	errs.Wrap(&err, "failed to deserialize hashes")
 
-	// The expected format is "sha256:<tls>;sha256:<app>".
+	// Examples of the serialized format are:
+	//   sha256:3CMEDy2oTLyBCLE2BufzgUy6zIY=;sha256:92AfmU4AXOKZpz61NGqqII12Tlw=
+	// or:
+	//   sha256:gDH6rnBA5e+dzTDeZv429hmWuYg=;sha256:
 	s := strings.Split(string(b), ";")
 	if len(s) != 2 {
 		return nil, errs.InvalidFormat
 	}
-	s[0] = strings.TrimPrefix(s[0], "sha256:")
-	s[1] = strings.TrimPrefix(s[1], "sha256:")
-
-	h = new(Hashes)
-	if _, err := base64.StdEncoding.Decode(h.TlsKeyHash[:], []byte(s[0])); err != nil {
-		return nil, errs.InvalidFormat
+	// Extract the base64-encoded hashes.
+	tlsKeyHash := []byte(strings.TrimPrefix(s[0], "sha256:"))
+	appKeyHash := []byte(strings.TrimPrefix(s[1], "sha256:"))
+	h = &Hashes{
+		TlsKeyHash: util.AddrOf([sha256.Size]byte{}),
 	}
-	if _, err := base64.StdEncoding.Decode(h.AppKeyHash[:], []byte(s[1])); err != nil {
-		return nil, errs.InvalidFormat
+
+	if _, err := base64.StdEncoding.Decode(
+		h.TlsKeyHash[:],
+		tlsKeyHash,
+	); err != nil {
+		return nil, fmt.Errorf("%w: %w", errs.InvalidFormat, err)
+	}
+
+	// If the application hash is unset, we're done.
+	if len(appKeyHash) == 0 {
+		return h, nil
+	}
+
+	h.AppKeyHash = util.AddrOf([sha256.Size]byte{})
+	if _, err := base64.StdEncoding.Decode(
+		h.AppKeyHash[:],
+		appKeyHash,
+	); err != nil {
+		return nil, fmt.Errorf("%w: %w", errs.InvalidFormat, err)
 	}
 
 	return h, nil

--- a/internal/service/attestation/hashes_test.go
+++ b/internal/service/attestation/hashes_test.go
@@ -1,0 +1,57 @@
+package attestation
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/Amnesic-Systems/veil/internal/errs"
+	"github.com/Amnesic-Systems/veil/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeSerialization(t *testing.T) {
+	var (
+		origHashes = new(Hashes)
+	)
+	origHashes.SetAppHash(util.AddrOf(sha256.Sum256([]byte("foo"))))
+	origHashes.SetTLSHash(util.AddrOf(sha256.Sum256([]byte("bar"))))
+
+	hashes, err := DeserializeHashes(origHashes.Serialize())
+	require.NoError(t, err)
+	require.Equal(t, origHashes, hashes)
+}
+
+func TestFailedDeserialization(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+	}{
+		{
+			name: "nil",
+			in:   nil,
+		},
+		{
+			name: "no separator",
+			in:   []byte("sha256:foo"),
+		},
+		{
+			name: "too many separators",
+			in:   []byte("sha256:foo;sha256:bar;sha256:baz"),
+		},
+		{
+			name: "invalid tls base64",
+			in:   []byte("sha256:123;sha256:456"),
+		},
+		{
+			name: "invalid app base64",
+			in:   []byte("sha256:Zm9vCg==;sha256:456"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := DeserializeHashes(c.in)
+			require.ErrorIs(t, err, errs.InvalidFormat)
+		})
+	}
+}

--- a/internal/service/handle/encode_test.go
+++ b/internal/service/handle/encode_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/httperr"
+	"github.com/Amnesic-Systems/veil/internal/service/attestation"
 )
 
 func TestEncodeAndAttest(t *testing.T) {
@@ -18,7 +19,7 @@ func TestEncodeAndAttest(t *testing.T) {
 		name       string
 		nonce      string
 		status     int
-		attester   enclave.Attester
+		builder    *attestation.Builder
 		body       interface{}
 		wantBody   string
 		wantStatus int
@@ -39,7 +40,7 @@ func TestEncodeAndAttest(t *testing.T) {
 			name:       "valid encoding",
 			nonce:      "hJkjpaP/6cVT+vikk06HcN0aOdU=",
 			status:     http.StatusOK,
-			attester:   enclave.NewNoopAttester(),
+			builder:    attestation.NewBuilder(enclave.NewNoopAttester()),
 			body:       httperr.New("random error"),
 			wantBody:   `{"error":"random error"}`,
 			wantStatus: http.StatusOK,
@@ -54,7 +55,7 @@ func TestEncodeAndAttest(t *testing.T) {
 				fmt.Sprintf("/foo?nonce=%s", url.QueryEscape(c.nonce)),
 				nil,
 			)
-			encodeAndAttest(rec, req, c.status, c.attester, c.body)
+			encodeAndAttest(rec, req, c.status, c.builder, c.body)
 
 			resp := rec.Result()
 			require.Equal(t, c.wantStatus, resp.StatusCode, httperr.FromBody(resp))

--- a/internal/service/routes.go
+++ b/internal/service/routes.go
@@ -20,14 +20,13 @@ func setupMiddlewares(r *chi.Mux, config *config.Config) {
 func addExternalPublicRoutes(
 	r *chi.Mux,
 	config *config.Config,
-	attester enclave.Attester,
-	auxFn attestation.AuxFunc,
+	builder *attestation.Builder,
 ) {
 	setupMiddlewares(r, config)
 
 	r.Get("/enclave", handle.Index(config))
-	r.Get("/enclave/config", handle.Config(attester, config))
-	r.Get("/enclave/attestation", handle.Attestation(attester, auxFn))
+	r.Get("/enclave/config", handle.Config(builder, config))
+	r.Get("/enclave/attestation", handle.Attestation(builder))
 
 	// Set up reverse proxy for the application' Web server.
 	if config.AppWebSrv != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -50,7 +50,11 @@ func Run(
 
 	// Initialize Web servers.
 	intSrv := newIntSrv(config, keys, hashes, appReady)
-	extSrv := newExtSrv(config, attester, attestation.AuxToClient(hashes))
+	builder := attestation.NewBuilder(
+		attester,
+		attestation.WithHashes(hashes),
+	)
+	extSrv := newExtSrv(config, builder)
 	extSrv.TLSConfig = &tls.Config{
 		Certificates: []tls.Certificate{
 			util.Must(tls.X509KeyPair(cert, key)),
@@ -150,11 +154,10 @@ func newIntSrv(
 
 func newExtSrv(
 	config *config.Config,
-	attester enclave.Attester,
-	auxFn attestation.AuxFunc,
+	builder *attestation.Builder,
 ) *http.Server {
 	r := chi.NewRouter()
-	addExternalPublicRoutes(r, config, attester, auxFn)
+	addExternalPublicRoutes(r, config, builder)
 
 	return &http.Server{
 		Addr:    net.JoinHostPort("0.0.0.0", config.ExtPubPort),


### PR DESCRIPTION
So far, the code would distinguish between the attester interface and the auxiliary information that's necessary for requesting and attestation document.  This made things somewhat cumbersome; especially when some auxiliary information (the enclave hashes) needs to be set early whereas other information needs to be set at attestation time (the nonce).

This PR adds a new abstraction, the `Builder` type, which bundles an attester with a mechanism to set auxiliary information at initialization time and at attestation time.