### PR TITLE
Ignore error if the interface already exists.

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"errors"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
@@ -98,7 +99,12 @@ func setupSystem(config *config.Config) (err error) {
 	if err := system.SeedRandomness(); err != nil {
 		return err
 	}
-	return system.SetupLo()
+	// When running unit tests inside a Nitro Enclave, the loopback interface
+	// may already exist, in which case we ignore the error.
+	if err := system.SetupLo(); err != nil && !errors.Is(err, fs.ErrExist) {
+		return err
+	}
+	return nil
 }
 
 func startAllWebSrvs(


### PR DESCRIPTION
When running unit tests inside a Nitro Enclave, we try to set up the loopback interface multiple times, which results in an error.  This isn't really an error though, and this commit fixes that.