### PR TITLE
Move `AddrOf` to its own package.

### DIFF
--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/enclave/nitro"
 	"github.com/Amnesic-Systems/veil/internal/enclave/noop"
@@ -295,7 +296,7 @@ func TestHashes(t *testing.T) {
 			return testutil.Client.Get(intSrv("/enclave/hashes"))
 		}
 	)
-	hashes.SetAppHash(util.AddrOf(sha256.Sum256([]byte("foo"))))
+	hashes.SetAppHash(addr.Of(sha256.Sum256([]byte("foo"))))
 
 	cases := []struct {
 		name       string

--- a/internal/addr/addr.go
+++ b/internal/addr/addr.go
@@ -1,0 +1,6 @@
+package addr
+
+// Of returns a pointer to the given value.
+func Of[T any](v T) *T {
+	return &v
+}

--- a/internal/addr/addr_test.go
+++ b/internal/addr/addr_test.go
@@ -1,0 +1,14 @@
+package addr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOf(t *testing.T) {
+	t.Parallel()
+
+	x := 1
+	require.Equal(t, &x, Of(x))
+}

--- a/internal/addr/doc.go
+++ b/internal/addr/doc.go
@@ -1,0 +1,2 @@
+// Package addr implements helper functions for dealing with pointers.
+package addr

--- a/internal/enclave/noop/attester_test.go
+++ b/internal/enclave/noop/attester_test.go
@@ -3,9 +3,9 @@ package noop
 import (
 	"testing"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/nonce"
-	"github.com/Amnesic-Systems/veil/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,9 +17,9 @@ func TestSuccessfulVerification(t *testing.T) {
 	var (
 		a       = NewAttester()
 		origAux = &enclave.AuxInfo{
-			PublicKey: util.AddrOf([enclave.AuxFieldLen]byte{'a', 'b', 'c'}),
-			UserData:  util.AddrOf([enclave.AuxFieldLen]byte{'d', 'e', 'f'}),
-			Nonce:     util.AddrOf([enclave.AuxFieldLen]byte{'g', 'h', 'i'}),
+			PublicKey: addr.Of([enclave.AuxFieldLen]byte{'a', 'b', 'c'}),
+			UserData:  addr.Of([enclave.AuxFieldLen]byte{'d', 'e', 'f'}),
+			Nonce:     addr.Of([enclave.AuxFieldLen]byte{'g', 'h', 'i'}),
 		}
 	)
 

--- a/internal/service/attestation/aux.go
+++ b/internal/service/attestation/aux.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"crypto/sha256"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/nonce"
-	"github.com/Amnesic-Systems/veil/internal/util"
 )
 
 // Builder is a helper for setting auxiliary attestation both at initialization
@@ -42,7 +42,7 @@ func (b *Builder) Attest(opts ...AuxField) (*enclave.AttestationDoc, error) {
 func WithHashes(h *Hashes) AuxField {
 	return func(b *Builder) {
 		if b.aux.PublicKey == nil {
-			b.aux.PublicKey = util.AddrOf([enclave.AuxFieldLen]byte{})
+			b.aux.PublicKey = addr.Of([enclave.AuxFieldLen]byte{})
 		}
 		copy(b.aux.PublicKey[:], h.Serialize())
 	}
@@ -52,7 +52,7 @@ func WithHashes(h *Hashes) AuxField {
 func WithNonce(n *nonce.Nonce) AuxField {
 	return func(b *Builder) {
 		if b.aux.Nonce == nil {
-			b.aux.Nonce = util.AddrOf([enclave.AuxFieldLen]byte{})
+			b.aux.Nonce = addr.Of([enclave.AuxFieldLen]byte{})
 		}
 		copy(b.aux.Nonce[:], n[:])
 	}
@@ -62,7 +62,7 @@ func WithNonce(n *nonce.Nonce) AuxField {
 func WithSHA256(sha [sha256.Size]byte) AuxField {
 	return func(b *Builder) {
 		if b.aux.UserData == nil {
-			b.aux.UserData = util.AddrOf([enclave.AuxFieldLen]byte{})
+			b.aux.UserData = addr.Of([enclave.AuxFieldLen]byte{})
 		}
 		copy(b.aux.UserData[:], sha[:])
 	}

--- a/internal/service/attestation/aux_test.go
+++ b/internal/service/attestation/aux_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/enclave/nitro"
 	"github.com/Amnesic-Systems/veil/internal/enclave/noop"
@@ -15,11 +16,11 @@ import (
 
 func TestGetters(t *testing.T) {
 	n := util.Must(nonce.New())
-	s := util.AddrOf(sha256.Sum256([]byte("foo")))
-	h1 := &Hashes{TlsKeyHash: util.AddrOf(sha256.Sum256([]byte("foo")))}
+	s := addr.Of(sha256.Sum256([]byte("foo")))
+	h1 := &Hashes{TlsKeyHash: addr.Of(sha256.Sum256([]byte("foo")))}
 	h2 := &Hashes{
-		TlsKeyHash: util.AddrOf(sha256.Sum256([]byte("foo"))),
-		AppKeyHash: util.AddrOf(sha256.Sum256([]byte("bar"))),
+		TlsKeyHash: addr.Of(sha256.Sum256([]byte("foo"))),
+		AppKeyHash: addr.Of(sha256.Sum256([]byte("bar"))),
 	}
 
 	cases := []struct {
@@ -82,8 +83,8 @@ func TestBuilder(t *testing.T) {
 	}
 	nonce1, nonce2 := util.Must(nonce.New()), util.Must(nonce.New())
 	sha1, sha2 := sha256.Sum256([]byte("foo")), sha256.Sum256([]byte("bar"))
-	hashes1 := &Hashes{TlsKeyHash: util.AddrOf(sha256.Sum256([]byte("foo")))}
-	hashes2 := &Hashes{TlsKeyHash: util.AddrOf(sha256.Sum256([]byte("bar")))}
+	hashes1 := &Hashes{TlsKeyHash: addr.Of(sha256.Sum256([]byte("foo")))}
+	hashes2 := &Hashes{TlsKeyHash: addr.Of(sha256.Sum256([]byte("bar")))}
 
 	cases := []struct {
 		name         string

--- a/internal/service/attestation/hashes.go
+++ b/internal/service/attestation/hashes.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/errs"
-	"github.com/Amnesic-Systems/veil/internal/util"
 )
 
 // Hashes contains hashes over public key material which we embed in
@@ -61,7 +61,7 @@ func DeserializeHashes(b []byte) (h *Hashes, err error) {
 	tlsKeyHash := []byte(strings.TrimPrefix(s[0], "sha256:"))
 	appKeyHash := []byte(strings.TrimPrefix(s[1], "sha256:"))
 	h = &Hashes{
-		TlsKeyHash: util.AddrOf([sha256.Size]byte{}),
+		TlsKeyHash: addr.Of([sha256.Size]byte{}),
 	}
 
 	if _, err := base64.StdEncoding.Decode(
@@ -76,7 +76,7 @@ func DeserializeHashes(b []byte) (h *Hashes, err error) {
 		return h, nil
 	}
 
-	h.AppKeyHash = util.AddrOf([sha256.Size]byte{})
+	h.AppKeyHash = addr.Of([sha256.Size]byte{})
 	if _, err := base64.StdEncoding.Decode(
 		h.AppKeyHash[:],
 		appKeyHash,

--- a/internal/service/attestation/hashes_test.go
+++ b/internal/service/attestation/hashes_test.go
@@ -4,8 +4,8 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/errs"
-	"github.com/Amnesic-Systems/veil/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,8 +13,8 @@ func TestDeSerialization(t *testing.T) {
 	var (
 		origHashes = new(Hashes)
 	)
-	origHashes.SetAppHash(util.AddrOf(sha256.Sum256([]byte("foo"))))
-	origHashes.SetTLSHash(util.AddrOf(sha256.Sum256([]byte("bar"))))
+	origHashes.SetAppHash(addr.Of(sha256.Sum256([]byte("foo"))))
+	origHashes.SetTLSHash(addr.Of(sha256.Sum256([]byte("bar"))))
 
 	hashes, err := DeserializeHashes(origHashes.Serialize())
 	require.NoError(t, err)

--- a/internal/service/handle/handlers.go
+++ b/internal/service/handle/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/config"
 	"github.com/Amnesic-Systems/veil/internal/httperr"
 	"github.com/Amnesic-Systems/veil/internal/httputil"
@@ -98,8 +99,8 @@ func AppHash(
 	setAppHash func(*[sha256.Size]byte),
 ) http.HandlerFunc {
 	b := util.Must(json.Marshal(&attestation.Hashes{
-		TlsKeyHash: util.AddrOf(sha256.Sum256([]byte("foo"))),
-		AppKeyHash: util.AddrOf(sha256.Sum256([]byte("bar"))),
+		TlsKeyHash: addr.Of(sha256.Sum256([]byte("foo"))),
+		AppKeyHash: addr.Of(sha256.Sum256([]byte("bar"))),
 	}))
 	maxHashesLen := len(b) + 1 // Allow extra byte for the \n.
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/Amnesic-Systems/veil/internal/addr"
 	"github.com/Amnesic-Systems/veil/internal/config"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/errs"
@@ -47,7 +48,7 @@ func Run(
 
 	// Initialize hashes for the attestation document.
 	hashes := new(attestation.Hashes)
-	hashes.SetTLSHash(util.AddrOf(sha256.Sum256(cert)))
+	hashes.SetTLSHash(addr.Of(sha256.Sum256(cert)))
 
 	// Initialize Web servers.
 	intSrv := newIntSrv(config, keys, hashes, appReady)

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -1,9 +1,5 @@
 package util
 
-func AddrOf[T any](v T) *T {
-	return &v
-}
-
 func Must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)

--- a/internal/util/common_test.go
+++ b/internal/util/common_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddrOf(t *testing.T) {
-	t.Parallel()
-
-	x := 1
-	require.Equal(t, &x, AddrOf(x))
-}
-
 func TestMust(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This allows us to replace the clunky `util.AddrOf` with the shorter and more descriptive `addr.Of`.