### PR TITLE
Handle more command line flags.

### DIFF
--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -30,6 +30,11 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 	fs := flag.NewFlagSet("veil", flag.ContinueOnError)
 	fs.SetOutput(out)
 
+	appWebSrv := fs.String(
+		"app-web-srv",
+		"localhost:8082",
+		"application web server",
+	)
 	debug := fs.Bool(
 		"debug",
 		false,
@@ -40,15 +45,20 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		defaultExtPubPort,
 		"external public port",
 	)
+	fqdn := fs.String(
+		"fqdn",
+		"",
+		"the enclave's fully qualified domain name",
+	)
 	intPort := fs.String(
 		"int-port",
 		defaultIntPort,
 		"internal port",
 	)
-	appWebSrv := fs.String(
-		"app-web-srv",
-		"localhost:8082",
-		"application web server",
+	sourceCodeURI := fs.String(
+		"source-code-uri",
+		"",
+		"source code URI",
 	)
 	waitForApp := fs.Bool(
 		"wait-for-app",
@@ -68,12 +78,14 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 
 	// Build and validate the config.
 	return &config.Config{
-		Debug:      *debug,
-		ExtPubPort: *extPubPort,
-		IntPort:    *intPort,
-		Testing:    *enableTesting,
-		WaitForApp: *waitForApp,
-		AppWebSrv:  util.Must(url.Parse(*appWebSrv)),
+		AppWebSrv:     util.Must(url.Parse(*appWebSrv)),
+		Debug:         *debug,
+		ExtPubPort:    *extPubPort,
+		FQDN:          *fqdn,
+		IntPort:       *intPort,
+		SourceCodeURI: *sourceCodeURI,
+		Testing:       *enableTesting,
+		WaitForApp:    *waitForApp,
 	}, nil
 }
 

--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -55,10 +55,10 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		defaultIntPort,
 		"internal port",
 	)
-	sourceCodeURI := fs.String(
-		"source-code-uri",
+	enclaveCodeURI := fs.String(
+		"enclave-code-uri",
 		"",
-		"source code URI",
+		"the enclave application's source code",
 	)
 	waitForApp := fs.Bool(
 		"wait-for-app",
@@ -78,14 +78,14 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 
 	// Build and validate the config.
 	return &config.Config{
-		AppWebSrv:     util.Must(url.Parse(*appWebSrv)),
-		Debug:         *debug,
-		ExtPubPort:    *extPubPort,
-		FQDN:          *fqdn,
-		IntPort:       *intPort,
-		SourceCodeURI: *sourceCodeURI,
-		Testing:       *enableTesting,
-		WaitForApp:    *waitForApp,
+		AppWebSrv:      util.Must(url.Parse(*appWebSrv)),
+		Debug:          *debug,
+		ExtPubPort:     *extPubPort,
+		FQDN:           *fqdn,
+		IntPort:        *intPort,
+		EnclaveCodeURI: *enclaveCodeURI,
+		Testing:        *enableTesting,
+		WaitForApp:     *waitForApp,
 	}, nil
 }
 

--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -174,6 +174,19 @@ func TestPages(t *testing.T) {
 	}
 }
 
+func TestEnclaveCodeURI(t *testing.T) {
+	const codeURI = "https://example.com"
+	defer stopSvc(startSvc(t, withFlags("-enclave-code-uri", codeURI)))
+
+	resp, err := testutil.Client.Get(extSrv("/enclave"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+
+	body := util.Must(io.ReadAll(resp.Body))
+	require.Contains(t, string(body), codeURI)
+}
+
 func TestReadyHandler(t *testing.T) {
 	defer stopSvc(startSvc(t, withFlags("-wait-for-app")))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,11 +47,11 @@ type Config struct {
 	// is only used by the enclave application.  This field is required.
 	IntPort string
 
-	// SourceCodeURI contains the URI of the software repository that's running
+	// EnclaveCodeURI contains the URI of the software repository that's running
 	// inside the enclave, e.g., "https://github.com/foo/bar".  The URL is shown
 	// on the enclave's index page, as part of instructions on how to do remote
 	// attestation.
-	SourceCodeURI string
+	EnclaveCodeURI string
 
 	// Testing facilitates local testing by disabling safety checks that we
 	// would normally run on the enclave and by using the noop attester instead

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,32 +12,13 @@ var _ = util.Validator(&Config{})
 
 // Config represents the configuration of our enclave service.
 type Config struct {
-	// SourceCodeURI contains the URI of the software repository that's running
-	// inside the enclave, e.g., "https://github.com/foo/bar".  The URL is shown
-	// on the enclave's index page, as part of instructions on how to do remote
-	// attestation.
-	SourceCodeURI string
-
-	// FQDN contains the fully qualified domain name that's set in the HTTPS
-	// certificate of the enclave's Web server, e.g. "example.com".  This field
-	// is required.
-	FQDN string
-
-	// ExtPubPort contains the TCP port that the public Web server should
-	// listen on, e.g. 443.  This port is not *directly* reachable by the
-	// Internet but the EC2 host's proxy *does* forward Internet traffic to
-	// this port.  This field is required.
-	ExtPubPort string
-
-	// IntPort contains the TCP port that the internal Web server should listen
-	// on, e.g., 8080.  This port is only reachable from within the enclave and
-	// is only used by the enclave application.  This field is required.
-	IntPort string
-
-	// Testing facilitates local testing by disabling safety checks that we
-	// would normally run on the enclave and by using the noop attester instead
-	// of the real attester.
-	Testing bool
+	// AppWebSrv should be set to the enclave-internal Web server of the
+	// enclave application, e.g., "http://127.0.0.1:8080".  Nitriding acts as a
+	// TLS-terminating reverse proxy and forwards incoming HTTP requests to
+	// this Web server.  Note that this configuration option is only necessary
+	// if the enclave application exposes an HTTP server.  Non-HTTP enclave
+	// applications can ignore this.
+	AppWebSrv *url.URL
 
 	// Debug can be set to true to see debug messages, i.e., if you are
 	// starting the enclave in debug mode by running:
@@ -50,13 +31,32 @@ type Config struct {
 	// nitro-cli's "--debug-mode" flag.
 	Debug bool
 
-	// AppWebSrv should be set to the enclave-internal Web server of the
-	// enclave application, e.g., "http://127.0.0.1:8080".  Nitriding acts as a
-	// TLS-terminating reverse proxy and forwards incoming HTTP requests to
-	// this Web server.  Note that this configuration option is only necessary
-	// if the enclave application exposes an HTTP server.  Non-HTTP enclave
-	// applications can ignore this.
-	AppWebSrv *url.URL
+	// ExtPubPort contains the TCP port that the public Web server should
+	// listen on, e.g. 443.  This port is not *directly* reachable by the
+	// Internet but the EC2 host's proxy *does* forward Internet traffic to
+	// this port.  This field is required.
+	ExtPubPort string
+
+	// FQDN contains the fully qualified domain name that's set in the HTTPS
+	// certificate of the enclave's Web server, e.g. "example.com".  This field
+	// is required.
+	FQDN string
+
+	// IntPort contains the TCP port that the internal Web server should listen
+	// on, e.g., 8080.  This port is only reachable from within the enclave and
+	// is only used by the enclave application.  This field is required.
+	IntPort string
+
+	// SourceCodeURI contains the URI of the software repository that's running
+	// inside the enclave, e.g., "https://github.com/foo/bar".  The URL is shown
+	// on the enclave's index page, as part of instructions on how to do remote
+	// attestation.
+	SourceCodeURI string
+
+	// Testing facilitates local testing by disabling safety checks that we
+	// would normally run on the enclave and by using the noop attester instead
+	// of the real attester.
+	Testing bool
 
 	// WaitForApp instructs nitriding to wait for the application's signal
 	// before launching the Internet-facing Web server.  Set this flag if your

--- a/internal/service/handle/handlers.go
+++ b/internal/service/handle/handlers.go
@@ -34,9 +34,9 @@ var (
 func Index(cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		page := "This host runs inside an AWS Nitro Enclave."
-		if cfg.SourceCodeURI != "" {
+		if cfg.EnclaveCodeURI != "" {
 			page += fmt.Sprintf("\nThe application's source code is available at: %s.",
-				cfg.SourceCodeURI)
+				cfg.EnclaveCodeURI)
 		}
 		fmt.Fprintln(w, page)
 	}


### PR DESCRIPTION
So far, the config struct would contain a couple variables that could not be set via the command line. This PR changes that.