### PR TITLE
Rename `ExtPubPort` to `ExtPort`.

### DIFF
--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	defaultExtPubPort = "8443"
-	defaultIntPort    = "8080"
+	defaultExtPort = "8443"
+	defaultIntPort = "8080"
 )
 
 func parseFlags(out io.Writer, args []string) (*config.Config, error) {
@@ -40,9 +40,9 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		false,
 		"enable debug logging",
 	)
-	extPubPort := fs.String(
+	extPort := fs.String(
 		"ext-pub-port",
-		defaultExtPubPort,
+		defaultExtPort,
 		"external public port",
 	)
 	fqdn := fs.String(
@@ -80,7 +80,7 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 	return &config.Config{
 		AppWebSrv:      util.Must(url.Parse(*appWebSrv)),
 		Debug:          *debug,
-		ExtPubPort:     *extPubPort,
+		ExtPort:        *extPort,
 		FQDN:           *fqdn,
 		IntPort:        *intPort,
 		EnclaveCodeURI: *enclaveCodeURI,

--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -102,7 +102,7 @@ func intSrv(path string) string {
 }
 
 func extSrv(path string) string {
-	return fmt.Sprintf("https://127.0.0.1:%s%s", defaultExtPubPort, path)
+	return fmt.Sprintf("https://127.0.0.1:%s%s", defaultExtPort, path)
 }
 
 func errFromBody(t *testing.T, resp *http.Response) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,11 +31,11 @@ type Config struct {
 	// nitro-cli's "--debug-mode" flag.
 	Debug bool
 
-	// ExtPubPort contains the TCP port that the public Web server should
+	// ExtPort contains the TCP port that the public Web server should
 	// listen on, e.g. 443.  This port is not *directly* reachable by the
 	// Internet but the EC2 host's proxy *does* forward Internet traffic to
 	// this port.  This field is required.
-	ExtPubPort string
+	ExtPort string
 
 	// FQDN contains the fully qualified domain name that's set in the HTTPS
 	// certificate of the enclave's Web server, e.g. "example.com".  This field
@@ -83,8 +83,8 @@ func (c *Config) Validate(_ context.Context) map[string]string {
 	problems := make(map[string]string)
 
 	// Check required fields.
-	if !isValidPort(c.ExtPubPort) {
-		problems["ExtPubPort"] = "must be a valid port number"
+	if !isValidPort(c.ExtPort) {
+		problems["ExtPort"] = "must be a valid port number"
 	}
 	if !isValidPort(c.IntPort) {
 		problems["IntPort"] = "must be a valid port number"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestConfig(t *testing.T) {
 	defaultConfig := Config{
-		ExtPubPort: "443",
-		IntPort:    "8081",
+		ExtPort: "443",
+		IntPort: "8081",
 	}
 
 	cases := []struct {
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 			cfgFn: func() *Config {
 				confCopy := defaultConfig
 				confCopy.IntPort = "foo"
-				confCopy.ExtPubPort = ""
+				confCopy.ExtPort = ""
 				return &confCopy
 			},
 			wantErrs: 2,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,38 +9,29 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	defaultConfig := Config{
-		ExtPort: "443",
-		IntPort: "8081",
-	}
-
 	cases := []struct {
 		name     string
-		cfgFn    func() *Config
+		cfg      *Config
 		wantErrs int
 	}{
 		{
-			name: "default config",
-			cfgFn: func() *Config {
-				return &defaultConfig
-			},
-			wantErrs: 0,
+			name: "valid config",
+			cfg:  &Config{ExtPort: "8443", IntPort: "8080"},
 		},
 		{
-			name: "missing ports",
-			cfgFn: func() *Config {
-				confCopy := defaultConfig
-				confCopy.IntPort = "foo"
-				confCopy.ExtPort = ""
-				return &confCopy
-			},
+			name: "still valid config",
+			cfg:  &Config{ExtPort: "1", IntPort: "65535"},
+		},
+		{
+			name:     "invalid ports",
+			cfg:      &Config{ExtPort: "0", IntPort: "foo"},
 			wantErrs: 2,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			errs := c.cfgFn().Validate(context.Background())
+			errs := c.cfg.Validate(context.Background())
 			require.Equal(t, c.wantErrs, len(errs), util.SprintErrs(errs))
 		})
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -161,7 +161,7 @@ func newExtSrv(
 	addExternalPublicRoutes(r, config, builder)
 
 	return &http.Server{
-		Addr:    net.JoinHostPort("0.0.0.0", config.ExtPubPort),
+		Addr:    net.JoinHostPort("0.0.0.0", config.ExtPort),
 		Handler: http.Handler(r),
 	}
 }


### PR DESCRIPTION
The old name was a relic of the past.  It's time to simplify.