### PR TITLE
Add `-silence-app` command line flag.

### DIFF
--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -132,7 +132,7 @@ func run(ctx context.Context, out io.Writer, args []string) (err error) {
 	if problems := cfg.Validate(ctx); len(problems) > 0 {
 		err := errors.New("invalid configuration")
 		for field, problem := range problems {
-			err = errors.Join(err, fmt.Errorf("field %q: %v", field, problem))
+			err = errors.Join(err, fmt.Errorf("field %s: %v", field, problem))
 		}
 		return err
 	}

--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -75,6 +75,11 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		"1.1.1.1",
 		"the DNS resolver used by veil",
 	)
+	silenceApp := fs.Bool(
+		"silence-app",
+		false,
+		"discard the application's stdout and stderr if -app-cmd is used",
+	)
 	testing := fs.Bool(
 		"insecure",
 		false,
@@ -101,6 +106,7 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		FQDN:           *fqdn,
 		IntPort:        *intPort,
 		Resolver:       *resolver,
+		SilenceApp:     *silenceApp,
 		Testing:        *testing,
 		WaitForApp:     *waitForApp,
 	}, nil
@@ -166,10 +172,10 @@ func eventuallyRunAppCmd(ctx context.Context, cfg *config.Config, cmd string) (e
 	}
 	log.Print("Internal service ready; running app command.")
 
-	return runAppCmd(ctx, cmd)
+	return runAppCmd(ctx, cmd, cfg.SilenceApp)
 }
 
-func runAppCmd(ctx context.Context, cmdStr string) error {
+func runAppCmd(ctx context.Context, cmdStr string, silence bool) error {
 	args := strings.Split(cmdStr, " ")
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
@@ -183,8 +189,12 @@ func runAppCmd(ctx context.Context, cmdStr string) error {
 	if err != nil {
 		return err
 	}
-	go forward(appStderr, io.Discard)
-	go forward(appStdout, io.Discard)
+	var out io.Writer = os.Stdout
+	if silence {
+		out = io.Discard
+	}
+	go forward(appStderr, out)
+	go forward(appStdout, out)
 
 	// Start the application and wait for it to terminate.
 	log.Println("Starting application.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,10 @@ type Config struct {
 	// should use, e.g., 1.1.1.1.
 	Resolver string
 
+	// SilenceApp can be set to discard the application's stdout and stderr if
+	// -app-cmd is used.
+	SilenceApp bool
+
 	// Testing facilitates local testing by disabling safety checks that we
 	// would normally run on the enclave and by using the noop attester instead
 	// of the real attester.
@@ -94,6 +98,11 @@ func (c *Config) Validate(_ context.Context) map[string]string {
 	}
 	if !isValidPort(c.IntPort) {
 		problems["IntPort"] = "must be a valid port number"
+	}
+
+	// Check invalid field combinations.
+	if c.SilenceApp && c.AppCmd == "" {
+		problems["SilenceApp"] = "requires -app-cmd to be set"
 	}
 
 	return problems

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,15 +94,15 @@ func (c *Config) Validate(_ context.Context) map[string]string {
 
 	// Check required fields.
 	if !isValidPort(c.ExtPort) {
-		problems["ExtPort"] = "must be a valid port number"
+		problems["-ext-port"] = "must be a valid port number"
 	}
 	if !isValidPort(c.IntPort) {
-		problems["IntPort"] = "must be a valid port number"
+		problems["-int-port"] = "must be a valid port number"
 	}
 
 	// Check invalid field combinations.
 	if c.SilenceApp && c.AppCmd == "" {
-		problems["SilenceApp"] = "requires -app-cmd to be set"
+		problems["-silence-app"] = "requires -app-cmd to be set"
 	}
 
 	return problems

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,24 @@ func TestConfig(t *testing.T) {
 			cfg:      &Config{ExtPort: 0, IntPort: 65536},
 			wantErrs: 2,
 		},
+		{
+			name: "invalid flag combination",
+			cfg: &Config{
+				SilenceApp: true,
+				ExtPort:    8443,
+				IntPort:    8080,
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "valid flag combination",
+			cfg: &Config{
+				SilenceApp: true,
+				AppCmd:     "echo",
+				ExtPort:    8443,
+				IntPort:    8080,
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This makes it possible to discard the application's stdout and stderr. So far, this was the default, and with the introduction of this flag, it is now possible to observe the application's output.