### PR TITLE
Attest request only if nonce is given.

### DIFF
--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"slices"
 	"sync"
@@ -141,10 +140,15 @@ func TestPages(t *testing.T) {
 			wantBody: "AWS Nitro Enclave",
 		},
 		{
-			name: "config",
-			url: extSrv(service.PathConfig + "?nonce=" + url.QueryEscape(
-				"hJkjpaP/6cVT+vikk06HcN0aOdU=",
-			)),
+			name:     "config without nonce",
+			url:      extSrv(service.PathConfig),
+			wantBody: `"Debug":false`,
+		},
+		{
+			name: "config with nonce",
+			url: extSrv(service.PathConfig + "?nonce=" +
+				util.Must(nonce.New()).URLEncode(),
+			),
 			wantBody: `"Debug":false`,
 		},
 	}

--- a/internal/service/handle/encode.go
+++ b/internal/service/handle/encode.go
@@ -23,6 +23,23 @@ func encode[T any](w http.ResponseWriter, status int, v T) {
 	}
 }
 
+func encodeAndMaybeAttest[T any](
+	w http.ResponseWriter,
+	r *http.Request,
+	status int,
+	builder *attestation.Builder,
+	v T,
+) {
+	// Depending on if the request contains a nonce, either return the JSON
+	// response without attestation or include an attestation document in the
+	// response.
+	if _, err := httpx.ExtractNonce(r); err != nil {
+		encode(w, status, v)
+	} else {
+		encodeAndAttest(w, r, status, builder, v)
+	}
+}
+
 func encodeAndAttest[T any](
 	w http.ResponseWriter,
 	r *http.Request,

--- a/internal/service/handle/handlers.go
+++ b/internal/service/handle/handlers.go
@@ -35,7 +35,7 @@ func Config(
 	cfg *config.Config,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		encodeAndAttest(w, r, http.StatusOK, builder, cfg)
+		encodeAndMaybeAttest(w, r, http.StatusOK, builder, cfg)
 	}
 }
 


### PR DESCRIPTION
So far, the config handler would always try to extract the nonce from the request in order to attest the response.  That's often annoying when you simply want to see the config and don't care about the attestation.

This PR makes attestation optional: if the nonce is given, the handler is going to create an attestation; if not, there won't be.