### PR TITLE
Don't set the application URL by default.

### DIFF
--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -55,9 +55,9 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		"the enclave application's source code",
 	)
 	extPort := fs.Int(
-		"ext-pub-port",
+		"ext-port",
 		defaultExtPort,
-		"external public port",
+		"external port",
 	)
 	fqdn := fs.String(
 		"fqdn",

--- a/cmd/veil/main.go
+++ b/cmd/veil/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Amnesic-Systems/veil/internal/httpx"
 	"github.com/Amnesic-Systems/veil/internal/service"
 	"github.com/Amnesic-Systems/veil/internal/tunnel"
-	"github.com/Amnesic-Systems/veil/internal/util"
 )
 
 const (
@@ -42,8 +41,8 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 	)
 	appWebSrv := fs.String(
 		"app-web-srv",
-		"localhost:8081",
-		"application web server",
+		"",
+		"application web server, e.g. http://localhost:8081",
 	)
 	debug := fs.Bool(
 		"debug",
@@ -91,15 +90,24 @@ func parseFlags(out io.Writer, args []string) (*config.Config, error) {
 		"wait for the application to signal readiness",
 	)
 
-	if err := fs.Parse(args); err != nil {
+	var err error
+	if err = fs.Parse(args); err != nil {
 		fs.PrintDefaults()
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	var u *url.URL
+	if *appWebSrv != "" {
+		u, err = url.Parse(*appWebSrv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse -app-web-srv: %w", err)
+		}
 	}
 
 	// Build and validate the config.
 	return &config.Config{
 		AppCmd:         *appCmd,
-		AppWebSrv:      util.Must(url.Parse(*appWebSrv)),
+		AppWebSrv:      u,
 		Debug:          *debug,
 		EnclaveCodeURI: *enclaveCodeURI,
 		ExtPort:        *extPort,

--- a/cmd/veil/main_test.go
+++ b/cmd/veil/main_test.go
@@ -111,10 +111,29 @@ func errFromBody(t *testing.T, resp *http.Response) string {
 }
 
 func TestBadConfig(t *testing.T) {
-	require.Error(t, run(context.Background(), io.Discard, []string{
-		// Provide an invalid port, which should cause the service to fail.
-		"-ext-pub-port", "foo",
-	}))
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "bad external port",
+			args: []string{"-ext-port", "foo"},
+		},
+		{
+			name: "bad internal port",
+			args: []string{"-int-port", "65536"},
+		},
+		{
+			name: "bad application url",
+			args: []string{"-app-web-srv", "http://localhost:foo"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Error(t, run(context.Background(), io.Discard, c.args))
+		})
+	}
 }
 
 func TestHelp(t *testing.T) {


### PR DESCRIPTION
...because that tells veil to set up its reverse proxy, which subsequently sends requests to a web server that doesn't exist. Instead, only try to parse the given web server if it's set.