### PR TITLE
Fix linter errors.

### DIFF
--- a/cmd/veil-daemon/main.go
+++ b/cmd/veil-daemon/main.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/Amnesic-Systems/veil/internal/config"
-	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/enclave/nitro"
 	"github.com/Amnesic-Systems/veil/internal/enclave/noop"
 	"github.com/Amnesic-Systems/veil/internal/errs"
@@ -155,7 +154,7 @@ func run(ctx context.Context, out io.Writer, args []string) (err error) {
 	}
 
 	// Initialize dependencies and start the service.
-	var attester enclave.Attester = nitro.NewAttester()
+	attester := nitro.NewAttester()
 	var tunneler tunnel.Mechanism = tunnel.NewVSOCK()
 	if cfg.Testing {
 		attester = noop.NewAttester()
@@ -214,7 +213,7 @@ func runAppCmd(ctx context.Context, cmdStr string, silence bool) error {
 func forward(from io.Reader, to io.Writer) {
 	s := bufio.NewScanner(from)
 	for s.Scan() {
-		fmt.Fprintln(to, s.Text())
+		_, _ = fmt.Fprintln(to, s.Text())
 	}
 	if err := s.Err(); err != nil {
 		log.Printf("Error reading application output: %v", err)

--- a/cmd/veil-daemon/main_test.go
+++ b/cmd/veil-daemon/main_test.go
@@ -180,7 +180,7 @@ func TestPages(t *testing.T) {
 
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			require.Contains(t, string(body), c.wantBody)
 		})
 	}
@@ -193,7 +193,7 @@ func TestEnclaveCodeURI(t *testing.T) {
 	resp, err := testutil.Client.Get(extSrv(service.PathIndex))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body := must.Get(io.ReadAll(resp.Body))
 	require.Contains(t, string(body), codeURI)
@@ -249,7 +249,7 @@ func TestReadyHandler(t *testing.T) {
 func TestAttestation(t *testing.T) {
 	defer stopSvc(startSvc(t, withFlags()))
 
-	var attester enclave.Attester = nitro.NewAttester()
+	attester := nitro.NewAttester()
 	if !nitro.IsEnclave() {
 		attester = noop.NewAttester()
 	}
@@ -289,7 +289,7 @@ func TestAttestation(t *testing.T) {
 			// Parse attestation document.
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			var a enclave.RawDocument
 			require.NoError(t, json.Unmarshal(body, &a))
 
@@ -370,7 +370,7 @@ func TestHashes(t *testing.T) {
 			// Read the response body and extract the hashes.
 			gotBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			var gotHashes attestation.Hashes
 			require.NoError(t, json.Unmarshal(gotBody, &gotHashes))
 
@@ -435,9 +435,8 @@ func TestReverseProxy(t *testing.T) {
 }
 
 func TestRunApp(t *testing.T) {
-	fd, err := os.CreateTemp("", "veil-test")
+	fd, err := os.CreateTemp(t.TempDir(), "veil-test")
 	require.NoError(t, err)
-	defer os.Remove(fd.Name())
 
 	cases := []struct {
 		name    string

--- a/cmd/veil-verify/attestation.go
+++ b/cmd/veil-verify/attestation.go
@@ -62,7 +62,7 @@ func attestEnclave(
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("enclave returned %q with body: %s", resp.Status, string(body))
 	}
@@ -76,7 +76,7 @@ func attestEnclave(
 	// Verify the attestation document, which provides assurance that we are
 	// talking to an enclave.  The nonce provides assurance that we are talking
 	// to an alive enclave (instead of a replayed attestation document).
-	var attester enclave.Attester = nitro.NewAttester()
+	attester := nitro.NewAttester()
 	if cfg.Testing {
 		attester = noop.NewAttester()
 	}

--- a/cmd/veil-verify/docker.go
+++ b/cmd/veil-verify/docker.go
@@ -338,10 +338,10 @@ func parsePCRsFromLogs(
 func printLogs(from io.Reader, to io.Writer) {
 	scanner := bufio.NewScanner(from)
 	for scanner.Scan() {
-		fmt.Fprintln(to, color.CyanString(scanner.Text()))
+		_, _ = fmt.Fprintln(to, color.CyanString(scanner.Text()))
 	}
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintln(to, err.Error())
+		_, _ = fmt.Fprintln(to, err.Error())
 	}
 }
 
@@ -362,7 +362,7 @@ func printDockerLogs(from io.Reader, to io.Writer) error {
 		if line == "" {
 			continue
 		}
-		fmt.Fprintln(to, color.CyanString(line))
+		_, _ = fmt.Fprintln(to, color.CyanString(line))
 	}
 }
 

--- a/cmd/veil-verify/main.go
+++ b/cmd/veil-verify/main.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, out io.Writer, args []string) error {
 		// provide useful context.
 		return errs.Add(err, "failed to create Docker client")
 	}
-	defer cli.Close()
+	defer func() { _ = cli.Close() }()
 	log.Print("Created Docker client.")
 
 	// Create a deterministically-built enclave image.  The image is written to

--- a/cmd/veil-verify/main_test.go
+++ b/cmd/veil-verify/main_test.go
@@ -27,7 +27,7 @@ func TestRun(t *testing.T) {
 	// Set up a test server that returns a dummy attestation.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
+		_, _ = fmt.Fprintf(w, `{
 			"type": "noop",
 			"attestation_document": "e30K"
 		}`) // e30K is Base64 for {}

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	InvalidFormat = errors.New("invalid format")
-	InvalidLength = errors.New("invalid length")
-	IsNil         = errors.New("argument must not be nil")
+	ErrInvalidFormat = errors.New("invalid format")
+	ErrInvalidLength = errors.New("invalid length")
+	ErrIsNil         = errors.New("argument must not be nil")
 )
 
 // Wrap wraps the given error using the given string and (if provided) string

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -91,7 +91,7 @@ func TestExtractNonce(t *testing.T) {
 			req: &http.Request{
 				URL: must.Get(url.Parse("https://example.com/endpoint?nonce=AAAAAAAAAAAAAA%3D%3D")),
 			},
-			wantErr: errs.InvalidLength,
+			wantErr: errs.ErrInvalidLength,
 		},
 		{
 			name: "valid nonce",

--- a/internal/net/proxy/proxy.go
+++ b/internal/net/proxy/proxy.go
@@ -21,7 +21,7 @@ func TunToVSOCK(
 	ch chan error,
 	wg *sync.WaitGroup,
 ) {
-	defer to.Close()
+	defer func() { _ = to.Close() }()
 	defer wg.Done()
 	var (
 		err       error
@@ -58,7 +58,7 @@ func VSOCKToTun(
 	ch chan error,
 	wg *sync.WaitGroup,
 ) {
-	defer to.Close()
+	defer func() { _ = to.Close() }()
 	defer wg.Done()
 	var (
 		err       error

--- a/internal/nonce/nonce.go
+++ b/internal/nonce/nonce.go
@@ -56,7 +56,7 @@ func New() (*Nonce, error) {
 func FromSlice(s []byte) (*Nonce, error) {
 	if len(s) < Len {
 		return nil, fmt.Errorf("%w: slice len is %d but need at least %d",
-			errs.InvalidLength, len(s), Len)
+			errs.ErrInvalidLength, len(s), Len)
 	}
 
 	var n Nonce

--- a/internal/nonce/nonce_test.go
+++ b/internal/nonce/nonce_test.go
@@ -22,7 +22,7 @@ func TestFromSlice(t *testing.T) {
 		{
 			name:    "too short",
 			in:      []byte{},
-			wantErr: errs.InvalidLength,
+			wantErr: errs.ErrInvalidLength,
 		},
 		{
 			name: "too long",

--- a/internal/service/attestation/aux.go
+++ b/internal/service/attestation/aux.go
@@ -12,7 +12,7 @@ import (
 // GetNonce returns the nonce from the given auxiliary info.
 func GetNonce(aux *enclave.AuxInfo) (*nonce.Nonce, error) {
 	if aux.Nonce == nil {
-		return nil, errs.IsNil
+		return nil, errs.ErrIsNil
 	}
 
 	var n nonce.Nonce
@@ -23,7 +23,7 @@ func GetNonce(aux *enclave.AuxInfo) (*nonce.Nonce, error) {
 // GetSHA256 returns the SHA256 hash from the given auxiliary info.
 func GetSHA256(aux *enclave.AuxInfo) (*[sha256.Size]byte, error) {
 	if aux.UserData == nil {
-		return nil, errs.IsNil
+		return nil, errs.ErrIsNil
 	}
 	sha := [sha256.Size]byte{}
 	copy(sha[:], aux.UserData[:])
@@ -32,7 +32,7 @@ func GetSHA256(aux *enclave.AuxInfo) (*[sha256.Size]byte, error) {
 
 func GetHashes(aux *enclave.AuxInfo) (*Hashes, error) {
 	if aux.PublicKey == nil {
-		return nil, errs.IsNil
+		return nil, errs.ErrIsNil
 	}
 	sanitized := bytes.Trim(aux.PublicKey[:], "\x00") // TODO: smth better?
 	return DeserializeHashes(sanitized)

--- a/internal/service/attestation/aux_test.go
+++ b/internal/service/attestation/aux_test.go
@@ -32,7 +32,7 @@ func TestGetters(t *testing.T) {
 		{
 			name:    "no fields",
 			aux:     &enclave.AuxInfo{},
-			wantErr: errs.IsNil,
+			wantErr: errs.ErrIsNil,
 		},
 		{
 			name: "all fields, some hashes",

--- a/internal/service/attestation/hashes.go
+++ b/internal/service/attestation/hashes.go
@@ -55,7 +55,7 @@ func DeserializeHashes(b []byte) (h *Hashes, err error) {
 	//   sha256:gDH6rnBA5e+dzTDeZv429hmWuYg=;sha256:
 	s := strings.Split(string(b), ";")
 	if len(s) != 2 {
-		return nil, errs.InvalidFormat
+		return nil, errs.ErrInvalidFormat
 	}
 	// Extract the base64-encoded hashes.
 	tlsKeyHash := []byte(strings.TrimPrefix(s[0], "sha256:"))
@@ -68,7 +68,7 @@ func DeserializeHashes(b []byte) (h *Hashes, err error) {
 		h.TlsKeyHash[:],
 		tlsKeyHash,
 	); err != nil {
-		return nil, fmt.Errorf("%w: %w", errs.InvalidFormat, err)
+		return nil, fmt.Errorf("%w: %w", errs.ErrInvalidFormat, err)
 	}
 
 	// If the application hash is unset, we're done.
@@ -81,7 +81,7 @@ func DeserializeHashes(b []byte) (h *Hashes, err error) {
 		h.AppKeyHash[:],
 		appKeyHash,
 	); err != nil {
-		return nil, fmt.Errorf("%w: %w", errs.InvalidFormat, err)
+		return nil, fmt.Errorf("%w: %w", errs.ErrInvalidFormat, err)
 	}
 
 	return h, nil

--- a/internal/service/attestation/hashes_test.go
+++ b/internal/service/attestation/hashes_test.go
@@ -51,7 +51,7 @@ func TestFailedDeserialization(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			_, err := DeserializeHashes(c.in)
-			require.ErrorIs(t, err, errs.InvalidFormat)
+			require.ErrorIs(t, err, errs.ErrInvalidFormat)
 		})
 	}
 }

--- a/internal/service/handle/encode.go
+++ b/internal/service/handle/encode.go
@@ -66,5 +66,5 @@ func encodeAndAttest[T any](
 	w.Header().Set(attestationHeader, string(b))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	fmt.Fprintln(w, string(body))
+	_, _ = fmt.Fprintln(w, string(body))
 }

--- a/internal/service/handle/encode_test.go
+++ b/internal/service/handle/encode_test.go
@@ -83,7 +83,7 @@ func TestEncodeAndAttest(t *testing.T) {
 			require.NoError(t, err)
 
 			// Ensure that the nonce is correct.
-			n, err := nonce.FromSlice(doc.AuxInfo.Nonce)
+			n, err := nonce.FromSlice(doc.Nonce)
 			require.NoError(t, err)
 			require.Equal(t, c.nonce, n)
 		})

--- a/internal/service/handle/handlers.go
+++ b/internal/service/handle/handlers.go
@@ -25,7 +25,7 @@ func Index(enclaveCodeURI string) http.HandlerFunc {
 			page += fmt.Sprintf("\nThe application's source code is available at: %s.",
 				enclaveCodeURI)
 		}
-		fmt.Fprintln(w, page)
+		_, _ = fmt.Fprintln(w, page)
 	}
 }
 

--- a/internal/tunnel/vsock.go
+++ b/internal/tunnel/vsock.go
@@ -74,7 +74,7 @@ func setupTunnel(
 	if err != nil {
 		return fmt.Errorf("failed to connect to veil-proxy: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	log.Println("Established TCP connection with veil-proxy.")
 
 	// Create and configure the tun device.
@@ -82,7 +82,7 @@ func setupTunnel(
 	if err != nil {
 		return fmt.Errorf("failed to set up tun device: %w", err)
 	}
-	defer tun.Close()
+	defer func() { _ = tun.Close() }()
 	log.Println("Set up tun device.")
 
 	// Spawn goroutines that forward traffic and wait for them to finish.


### PR DESCRIPTION
This PR pacifies golangci-lint. Some time soon, we should improve logging (e.g. use slog for structured logging, and don't discard errors like failing to close request bodies) but this will do for now.