### PR TITLE
Improve tunnel mechanism interface.

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -68,7 +68,9 @@ func Run(
 
 	// Set up the networking tunnel. This function will block until the tunnel
 	// is ready to use.
-	tunnel.New(ctx, mechanism, cfg.VSOCKPort)
+	if err := tunnel.New(ctx, mechanism, cfg.VSOCKPort); err != nil {
+		log.Fatalf("Failed to set up tunnel: %v", err)
+	}
 
 	// Start all Web servers and block until all Web servers have stopped, which
 	// should only happen if the given context is canceled.

--- a/internal/tunnel/noop.go
+++ b/internal/tunnel/noop.go
@@ -1,9 +1,6 @@
 package tunnel
 
-import (
-	"context"
-	"sync"
-)
+import "context"
 
 type NoopTunneler struct{}
 
@@ -11,6 +8,6 @@ func NewNoop() *NoopTunneler {
 	return &NoopTunneler{}
 }
 
-func (t *NoopTunneler) Start(_ context.Context, wg *sync.WaitGroup, _ uint32) {
-	wg.Done()
+func (t *NoopTunneler) Start(_ context.Context, _ uint32) error {
+	return nil
 }

--- a/internal/tunnel/noop_test.go
+++ b/internal/tunnel/noop_test.go
@@ -1,20 +1,11 @@
 package tunnel
 
 import (
-	"context"
-	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNoopTunneler(t *testing.T) {
-	var (
-		tunnel = NewNoop()
-		ctx    = context.Background()
-		wg     = new(sync.WaitGroup)
-	)
-	wg.Add(1)
-	defer wg.Wait()
-	defer ctx.Done()
-
-	tunnel.Start(ctx, wg, 0)
+	require.NoError(t, NewNoop().Start(t.Context(), 0))
 }

--- a/internal/tunnel/tunneler.go
+++ b/internal/tunnel/tunneler.go
@@ -2,7 +2,6 @@ package tunnel
 
 import (
 	"context"
-	"sync"
 )
 
 var (
@@ -11,14 +10,11 @@ var (
 )
 
 type Mechanism interface {
-	// Start starts the tunneling mechanism.  It returns immediately and calls
-	// `Done()` on the given waitgroup after networking is set up.
-	Start(context.Context, *sync.WaitGroup, uint32)
+	// Start starts the tunneling mechanism and blocks until networking is set up
+	// or the context is canceled before setup completes.
+	Start(ctx context.Context, port uint32) error
 }
 
-func New(ctx context.Context, m Mechanism, port uint32) {
-	var wg = new(sync.WaitGroup)
-	wg.Add(1)
-	defer wg.Wait()
-	m.Start(ctx, wg, port)
+func New(ctx context.Context, m Mechanism, port uint32) error {
+	return m.Start(ctx, port)
 }

--- a/internal/tunnel/vsock.go
+++ b/internal/tunnel/vsock.go
@@ -35,24 +35,44 @@ func NewVSOCK() *VsockTunneler {
 
 func (v *VsockTunneler) Start(
 	ctx context.Context,
-	wg *sync.WaitGroup,
 	port uint32,
-) {
-	defer wg.Done()
+) error {
+	readyCh := make(chan struct{})
+	var ready sync.Once
 
 	go func() {
+		defer ready.Do(func() { close(readyCh) })
+
 		var err error
 		for {
-			if err = setupTunnel(ctx, &v.backoff, port); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err = setupTunnel(ctx, &v.backoff, port, func() {
+				ready.Do(func() { close(readyCh) })
+			}); err != nil {
 				log.Printf("Error: %v", err)
 			}
-			time.Sleep(v.backoff)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(v.backoff):
+			}
 			v.backoff = v.backoff * 2
 			if v.backoff > maxBackoff {
 				v.backoff = maxBackoff
 			}
 		}
 	}()
+
+	select {
+	case <-readyCh:
+		return ctx.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // setupTunnel establishes a tunnel between the enclave and the parent EC2 and
@@ -62,11 +82,12 @@ func setupTunnel(
 	ctx context.Context,
 	backoff *time.Duration,
 	port uint32,
+	ready func(),
 ) (err error) {
 	defer errs.Wrap(&err, "tunnel failed")
 	var (
 		wg    sync.WaitGroup
-		errCh = make(chan error, 1)
+		errCh = make(chan error, 2)
 	)
 
 	// Establish TCP-over-VSOCK connection with veil-proxy.
@@ -91,6 +112,7 @@ func setupTunnel(
 	go proxy.VSOCKToTun(conn, tun, errCh, &wg)
 	go proxy.TunToVSOCK(tun, conn, errCh, &wg)
 	log.Println("Started goroutines to forward traffic.")
+	ready()
 
 	// Reset the backoff interval.
 	*backoff = minBackoff

--- a/internal/tunnel/vsock_test.go
+++ b/internal/tunnel/vsock_test.go
@@ -2,19 +2,14 @@ package tunnel
 
 import (
 	"context"
-	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestVsockTunneler(t *testing.T) {
-	var (
-		tunnel = NewVSOCK()
-		ctx    = context.Background()
-		wg     = new(sync.WaitGroup)
-	)
-	wg.Add(1)
-	defer wg.Wait()
-	defer ctx.Done()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
-	tunnel.Start(ctx, wg, 0)
+	require.ErrorIs(t, NewVSOCK().Start(ctx, 0), context.Canceled)
 }


### PR DESCRIPTION
So far, the tunnel mechanism interface would take as input a wait group that was supposed to complete when the tunnel is set up. That wasn't done correctly though: it would complete when `Start` was done but the tunnel may not be set up at that point because that's happening in a goroutine.

This PR improves the `Mechanism` interface by removing the wait group and expecting implementations to block until the tunnel is ready. While at it, I made a few small improvements, like aborting exponential backoff if the given context is done.