### PR TITLE
Add package for exponential backoff.

### DIFF
--- a/cmd/veil-proxy/main.go
+++ b/cmd/veil-proxy/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"sync"
 
+	"github.com/Amnesic-Systems/veil/internal/backoff"
 	"github.com/Amnesic-Systems/veil/internal/config"
 	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/net/nat"
@@ -58,7 +62,7 @@ func listenVSOCK(port uint32) (_ net.Listener, err error) {
 	return vsock.ListenContextID(cid, port, nil)
 }
 
-func acceptLoop(ln net.Listener) {
+func acceptLoop(ctx context.Context, ln net.Listener) {
 	// Print errors that occur while forwarding packets.
 	ch := make(chan error)
 	defer close(ch)
@@ -68,34 +72,50 @@ func acceptLoop(ln net.Listener) {
 		}
 	}(ch)
 
+	timer := backoff.NewTimer()
 	// Listen for connections from the enclave and begin forwarding packets
 	// once a new connection is established. At any given point, we only expect
 	// to have a single TCP-over-VSOCK connection with the enclave.
 	for {
-		tunDev, err := tun.SetupTunAsProxy()
-		if err != nil {
-			log.Printf("Error creating tun device: %v", err)
-			continue
-		}
-		log.Print("Created tun device.")
+		if err := func() error { // Use a function so we can use defer below.
+			log.Println("Waiting for new connection from enclave.")
+			vm, err := ln.Accept()
+			if err != nil {
+				return fmt.Errorf("failed to accept connection: %w", err)
+			}
+			defer func() { _ = vm.Close() }()
+			log.Printf("Accepted new connection from %s.", vm.RemoteAddr())
 
-		log.Println("Waiting for new connection from enclave.")
-		vm, err := ln.Accept()
-		if err != nil {
-			log.Printf("Error accepting connection: %v", err)
-			continue
-		}
-		log.Printf("Accepted new connection from %s.", vm.RemoteAddr())
+			tunDev, err := tun.SetupTunAsProxy()
+			if err != nil {
+				return fmt.Errorf("failed to create tun device: %w", err)
+			}
+			defer func() { _ = tunDev.Close() }()
+			log.Print("Created tun device.")
 
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go proxy.VSOCKToTun(vm, tunDev, ch, &wg)
-		go proxy.TunToVSOCK(tunDev, vm, ch, &wg)
-		wg.Wait()
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go proxy.VSOCKToTun(vm, tunDev, ch, &wg)
+			go proxy.TunToVSOCK(tunDev, vm, ch, &wg)
+			wg.Wait()
+
+			return nil
+		}(); err != nil {
+			if ctx.Err() != nil {
+				return // Main context is done; time to exit.
+			}
+			log.Printf("Failed to set up tunnel: %v", err)
+			timer.Sleep(ctx)
+		} else {
+			timer.Reset()
+		}
 	}
 }
 
-func run(out io.Writer, args []string) (origErr error) {
+func run(ctx context.Context, out io.Writer, args []string) (origErr error) {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
+	defer cancel()
+
 	cfg, err := parseFlags(out, args)
 	if err != nil {
 		return err
@@ -117,8 +137,9 @@ func run(out io.Writer, args []string) (origErr error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		errs.Join(&origErr, errs.Add(ln.Close(), "failed to close listener"))
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
 	}()
 
 	// If desired, set up a Web server for the profiler.
@@ -135,12 +156,12 @@ func run(out io.Writer, args []string) (origErr error) {
 
 	// Accept new connections from the VSOCK listener and begin forwarding
 	// packets.
-	acceptLoop(ln)
+	acceptLoop(ctx, ln)
 	return nil
 }
 
 func main() {
-	if err := run(os.Stdout, os.Args[1:]); err != nil {
+	if err := run(context.Background(), os.Stdout, os.Args[1:]); err != nil {
 		log.Fatalf("Failed to run proxy: %v", err)
 	}
 }

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,57 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	minSleep = 100 * time.Millisecond
+	maxSleep = 10 * time.Second
+)
+
+type Timer struct {
+	cur, max   time.Duration
+	resetAfter time.Duration
+	lastFail   time.Time
+	sleepFn    func(context.Context, time.Duration)
+}
+
+func NewTimer(opts ...Opts) *Timer {
+	t := &Timer{
+		max:        maxSleep,
+		resetAfter: 10 * time.Second,
+		sleepFn: func(ctx context.Context, d time.Duration) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(d):
+			}
+		},
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *Timer) Sleep(ctx context.Context) {
+	now := time.Now().UTC()
+	// Has enough time passed to reset the backoff duration?
+	if !t.lastFail.IsZero() && now.Sub(t.lastFail) >= t.resetAfter {
+		t.cur = minSleep
+	}
+	if t.cur <= minSleep {
+		t.cur = minSleep
+	}
+
+	d := t.cur
+	t.cur = min(t.max, t.cur*2)
+	t.lastFail = now
+
+	t.sleepFn(ctx, d)
+}
+
+func (t *Timer) Reset() {
+	t.cur = minSleep
+	t.lastFail = time.Time{}
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,120 @@
+package backoff
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type sleepRecorder struct {
+	durations []time.Duration
+}
+
+func (r *sleepRecorder) Sleep(_ context.Context, d time.Duration) {
+	r.durations = append(r.durations, d)
+}
+
+func newTestTimer(opts ...Opts) (*Timer, *sleepRecorder) {
+	recorder := new(sleepRecorder)
+	opts = append([]Opts{WithSleepFn(recorder.Sleep)}, opts...)
+	timer := NewTimer(opts...)
+	return timer, recorder
+}
+
+func TestTimerStartsAtMinSleep(t *testing.T) {
+	timer, recorder := newTestTimer()
+
+	timer.Sleep(t.Context())
+
+	require.Equal(t, []time.Duration{minSleep}, recorder.durations)
+	require.Equal(t, minSleep*2, timer.cur)
+	require.False(t, timer.lastFail.IsZero())
+}
+
+func TestTimerBacksOffExponentiallyUntilMax(t *testing.T) {
+	const max = minSleep * 4
+	timer, recorder := newTestTimer(WithMaxBackoff(max))
+
+	for range 5 {
+		timer.Sleep(t.Context())
+	}
+
+	require.Equal(t, []time.Duration{
+		minSleep,
+		minSleep * 2,
+		max,
+		max,
+		max,
+	}, recorder.durations)
+	require.Equal(t, max, timer.cur)
+}
+
+func TestTimerResetsAfterQuietPeriod(t *testing.T) {
+	timer, recorder := newTestTimer(WithMaxBackoff(minSleep * 8))
+
+	timer.Sleep(t.Context())
+	timer.Sleep(t.Context())
+	timer.Sleep(t.Context())
+
+	timer.lastFail = time.Now().UTC().Add(-timer.resetAfter)
+	timer.Sleep(t.Context())
+
+	require.Equal(t, []time.Duration{
+		minSleep,
+		minSleep * 2,
+		minSleep * 4,
+		minSleep,
+	}, recorder.durations)
+	require.Equal(t, minSleep*2, timer.cur)
+}
+
+func TestTimerDoesNotResetBeforeQuietPeriod(t *testing.T) {
+	timer, recorder := newTestTimer(WithMaxBackoff(minSleep * 8))
+
+	timer.Sleep(t.Context())
+	timer.Sleep(t.Context())
+
+	timer.lastFail = time.Now().UTC().Add(-timer.resetAfter + time.Millisecond)
+	timer.Sleep(t.Context())
+
+	require.Equal(t, []time.Duration{
+		minSleep,
+		minSleep * 2,
+		minSleep * 4,
+	}, recorder.durations)
+	require.Equal(t, minSleep*8, timer.cur)
+}
+
+func TestTimerPassesContextToSleepFn(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "sentinel")
+	var got context.Context
+	timer := NewTimer(WithSleepFn(func(ctx context.Context, _ time.Duration) {
+		got = ctx
+	}))
+
+	timer.Sleep(ctx)
+
+	require.Equal(t, "sentinel", got.Value(contextKey{}))
+}
+
+func TestDefaultSleepReturnsWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	timer := NewTimer()
+	timer.cur = maxSleep
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		timer.Sleep(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Millisecond):
+		require.Fail(t, "Sleep did not return after context cancellation")
+	}
+}

--- a/internal/backoff/options.go
+++ b/internal/backoff/options.go
@@ -1,0 +1,20 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+type Opts func(t *Timer)
+
+func WithMaxBackoff(max time.Duration) Opts {
+	return func(t *Timer) {
+		t.max = max
+	}
+}
+
+func WithSleepFn(sleepFn func(context.Context, time.Duration)) Opts {
+	return func(t *Timer) {
+		t.sleepFn = sleepFn
+	}
+}

--- a/internal/tunnel/vsock.go
+++ b/internal/tunnel/vsock.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 	"sync"
-	"time"
 
+	"github.com/Amnesic-Systems/veil/internal/backoff"
 	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/net/proxy"
 	"github.com/Amnesic-Systems/veil/internal/net/tun"
@@ -18,18 +18,16 @@ const (
 	// EC2 instance. According to AWS docs, it is always 3:
 	// https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html
 	proxyCID         = 3
-	minBackoff       = time.Second
-	maxBackoff       = time.Second * 10
 	DefaultVSOCKPort = 1024
 )
 
 type VsockTunneler struct {
-	backoff time.Duration
+	timer *backoff.Timer
 }
 
 func NewVSOCK() *VsockTunneler {
 	return &VsockTunneler{
-		backoff: minBackoff,
+		timer: backoff.NewTimer(),
 	}
 }
 
@@ -49,21 +47,12 @@ func (v *VsockTunneler) Start(
 				return
 			}
 
-			if err = setupTunnel(ctx, &v.backoff, port, func() {
+			if err = setupTunnel(ctx, v.timer, port, func() {
 				ready.Do(func() { close(readyCh) })
 			}); err != nil {
 				log.Printf("Error: %v", err)
 			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(v.backoff):
-			}
-			v.backoff = v.backoff * 2
-			if v.backoff > maxBackoff {
-				v.backoff = maxBackoff
-			}
+			v.timer.Sleep(ctx)
 		}
 	}()
 
@@ -80,7 +69,7 @@ func (v *VsockTunneler) Start(
 // torn down.
 func setupTunnel(
 	ctx context.Context,
-	backoff *time.Duration,
+	timer *backoff.Timer,
 	port uint32,
 	ready func(),
 ) (err error) {
@@ -115,7 +104,7 @@ func setupTunnel(
 	ready()
 
 	// Reset the backoff interval.
-	*backoff = minBackoff
+	timer.Reset()
 
 	select {
 	// Return the first error that occurs.


### PR DESCRIPTION
This PR adds a new package that handles exponential backoff in retry loops. Two places in the code benefit from this: the proxy's accept loop and the "other side", which is the enclave's retry loop. This will also make the code more robust when the proxy is terminated.