### PR TITLE
Fix race in tests.

### DIFF
--- a/cmd/veil-daemon/main_test.go
+++ b/cmd/veil-daemon/main_test.go
@@ -205,6 +205,7 @@ func TestReadyHandler(t *testing.T) {
 	cases := []struct {
 		name     string
 		url      string
+		wait     bool
 		wantCode int
 		wantErr  error
 	}{
@@ -228,6 +229,7 @@ func TestReadyHandler(t *testing.T) {
 		{
 			name:     "2nd attempt public",
 			url:      extSrv(service.PathIndex),
+			wait:     true,
 			wantCode: http.StatusOK,
 			wantErr:  nil,
 		},
@@ -235,12 +237,24 @@ func TestReadyHandler(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			if c.wait {
+				deadline, cancel := context.WithDeadline(
+					t.Context(),
+					time.Now().Add(100*time.Millisecond),
+				)
+				defer cancel()
+				require.NoError(t,
+					httpx.WaitForSvc(deadline, httpx.NewUnauthClient(), c.url),
+				)
+			}
+
 			resp, err := testutil.Client.Get(c.url)
 			if c.wantErr != nil {
 				require.ErrorIs(t, err, c.wantErr)
 				return
 			}
 			require.NoError(t, err)
+			defer func() { assert.NoError(t, resp.Body.Close()) }()
 			require.Equal(t, c.wantCode, resp.StatusCode)
 		})
 	}

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -104,7 +104,9 @@ func WaitForSvc(
 
 	for {
 		log.Print("Making request to service...")
-		if _, err := client.Do(req); err == nil {
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
 			log.Print("Service is ready.")
 			return nil
 		}


### PR DESCRIPTION
`TestReadyHandler` sometimes fails because the test attempts to fetch the enclave's index page before the code was done setting up the external web server. Taking advantage of `WaitForSvc` should fix this issue.