### PR TITLE
Only run CI on pull requests.

### DIFF
--- a/.github/workflows/veil.yml
+++ b/.github/workflows/veil.yml
@@ -4,7 +4,6 @@
 name: veil
 
 on:
-  push:
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
No need to have it run on pushes too.