### PR TITLE
Run CI when merging into `master`.

### DIFF
--- a/.github/workflows/veil.yml
+++ b/.github/workflows/veil.yml
@@ -6,6 +6,8 @@ name: veil
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   Test:


### PR DESCRIPTION
So far, we would only run CI on pull request creation but there's merit in also running it on merge into `master`, if other PRs were merged in the meanwhile.