### PR TITLE
Fix in-enclave unit tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ enclave: $(godeps) $(image_eif) terminate
 		--enclave-name veil \
 		--eif-path $(image_eif) \
 		--cpu-count 2 \
-		--memory 3850
+		--memory 4096
 
-$(image_test_tar): $(godeps) $(image_test_dockerfile)
+$(image_test_tar): $(godeps) $(image_test_dockerfile) docker/run-unit-tests.sh
 	@echo "Building $(image_test_tar)..."
 	@docker run --volume $(PWD):/workspace \
 		gcr.io/kaniko-project/executor:v1.9.2 \
@@ -84,7 +84,7 @@ enclave-test: $(godeps) $(image_test_eif) terminate
 		--eif-path $(image_test_eif) \
 		--attach-console \
 		--cpu-count 2 \
-		--memory 3850
+		--memory 4096
 
 .PHONY: terminate
 terminate:

--- a/docker/Dockerfile-unit-test
+++ b/docker/Dockerfile-unit-test
@@ -7,18 +7,8 @@ COPY cmd/ ./cmd/
 COPY internal/ ./internal/
 COPY vendor/ ./vendor/
 COPY Makefile go.mod go.sum ./
-RUN cat > ./run-unit-tests.sh <<EOF
-#!/usr/bin/env bash
-cd /app
-# Needed for Go's build cache.
-export HOME=/app
-# Needed because otherwise we're getting:
-# fork/exec /tmp/go-build1885828642/b001/cmd.test: permission denied
-mkdir -p /app/tmp
-export TMPDIR=/app/tmp
-echo "Running Go unit tests..."
-$(which go) test -cover ./...
-EOF
+COPY docker/run-unit-tests.sh ./run-unit-tests.sh
+RUN chmod +x ./run-unit-tests.sh
 
 RUN go mod download
 

--- a/docker/run-unit-tests.sh
+++ b/docker/run-unit-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cd /app
+# Needed for Go's build cache.
+export HOME=/app
+# Needed because otherwise we're getting:
+# fork/exec /tmp/go-build1885828642/b001/cmd.test: permission denied
+mkdir -p /app/tmp
+export TMPDIR=/app/tmp
+echo "Running Go unit tests..."
+$(which go) test -cover ./...


### PR DESCRIPTION
I noticed that code rot resulted in the in-enclave unit tests failing. The run-unit-tests.sh file ended up being empty, which resulted in the enclave terminating right away. This PR makes the Dockerfile explicitly copy the file, and it bumps memory limits.