### PR TITLE
Return error if attestation fails.

### DIFF
--- a/cmd/veil-verify/attestation.go
+++ b/cmd/veil-verify/attestation.go
@@ -100,11 +100,11 @@ func attestEnclave(
 	if !pcrs.Equal(doc.PCRs) {
 		log.Printf("Expected PCRs:\n%sbut got PCRs:\n%s", pcrs, doc.PCRs)
 		color.Red("Enclave's code DOES NOT match local code!")
+		return errors.New("enclave code does not match local code")
 	} else {
 		color.Green("Enclave's code matches local code!")
+		return nil
 	}
-
-	return nil
 }
 
 func buildReq(


### PR DESCRIPTION
So far, we would log but not return an error if we failed to attest an enclave. That can be a problem if veil-verify is used inside a script: the exit code must be non-zero if attestation failed, which is what this PR does.