### PR TITLE
fix(tun): make tunnel MTU configurable

### DIFF
--- a/cmd/veil-daemon/main.go
+++ b/cmd/veil-daemon/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Amnesic-Systems/veil/internal/enclave/noop"
 	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/httpx"
+	"github.com/Amnesic-Systems/veil/internal/net/tun"
 	"github.com/Amnesic-Systems/veil/internal/service"
 	"github.com/Amnesic-Systems/veil/internal/tunnel"
 	"github.com/Amnesic-Systems/veil/internal/types/validate"
@@ -100,6 +101,11 @@ func parseFlags(out io.Writer, args []string) (*config.Veil, error) {
 		tunnel.DefaultVSOCKPort,
 		"VSOCK port that veil-proxy is listening on",
 	)
+	tunMTU := fs.Int(
+		"tun-mtu",
+		tun.DefaultMTU,
+		"MTU of the tunnel TUN interface (default 65535); must match on veil-proxy and veil-daemon",
+	)
 	waitForApp := fs.Bool(
 		"wait-for-app",
 		false,
@@ -134,6 +140,7 @@ func parseFlags(out io.Writer, args []string) (*config.Veil, error) {
 		SilenceApp:     *silenceApp,
 		Testing:        *testing,
 		VSOCKPort:      uint32(*vsockPort),
+		TunMTU:         *tunMTU,
 		WaitForApp:     *waitForApp,
 	}
 	return cfg, validate.Object(cfg)

--- a/cmd/veil-proxy/main.go
+++ b/cmd/veil-proxy/main.go
@@ -50,6 +50,11 @@ to the nameservers configured in /etc/resolv.conf.`,
 		tunnel.DefaultVSOCKPort,
 		"VSOCK listening port that veil connects to.",
 	)
+	tunMTU := fs.Int(
+		"tun-mtu",
+		tun.DefaultMTU,
+		"MTU of the tunnel TUN interface (default 65535); must match on veil-proxy and veil-daemon",
+	)
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -59,6 +64,7 @@ to the nameservers configured in /etc/resolv.conf.`,
 		DNSForwarder: *dnsForwarder,
 		Profile:      *profile,
 		VSOCKPort:    uint32(*vsockPort),
+		TunMTU:       *tunMTU,
 	}
 	return cfg, validate.Object(cfg)
 }
@@ -97,7 +103,7 @@ func acceptLoop(ctx context.Context, ln net.Listener, cfg *config.VeilProxy) {
 			defer func() { _ = vm.Close() }()
 			log.Printf("Accepted new connection from %s.", vm.RemoteAddr())
 
-			tunDev, err := tun.SetupTunAsProxy()
+			tunDev, err := tun.SetupTunAsProxy(tun.Config{MTU: cfg.TunMTU})
 			if err != nil {
 				return fmt.Errorf("failed to create tun device: %w", err)
 			}
@@ -112,6 +118,8 @@ func acceptLoop(ctx context.Context, ln net.Listener, cfg *config.VeilProxy) {
 				defer func() { _ = dns.Close() }()
 				log.Printf("Started DNS forwarder at %s.", dns.UDPAddr())
 			}
+
+			mtu := config.TunMTUOrDefault(cfg.TunMTU)
 
 			// Close vm and tunDev when the context is canceled to
 			// unblock the forwarding goroutines before wg.Wait().
@@ -128,8 +136,8 @@ func acceptLoop(ctx context.Context, ln net.Listener, cfg *config.VeilProxy) {
 
 			var wg sync.WaitGroup
 			wg.Add(2)
-			go proxy.VSOCKToTun(vm, tunDev, ch, &wg)
-			go proxy.TunToVSOCK(tunDev, vm, ch, &wg)
+			go proxy.VSOCKToTun(vm, tunDev, mtu, ch, &wg)
+			go proxy.TunToVSOCK(tunDev, vm, mtu, ch, &wg)
 			wg.Wait()
 
 			return nil

--- a/internal/config/veil.go
+++ b/internal/config/veil.go
@@ -82,6 +82,9 @@ type Veil struct {
 	// on the EC2 host.
 	VSOCKPort uint32
 
+	// TunMTU is the tunnel interface MTU in bytes. Zero selects the default.
+	TunMTU int
+
 	// WaitForApp instructs veil to wait for the application's signal
 	// before launching the Internet-facing Web server.  Set this flag if your
 	// application takes a while to bootstrap and you don't want to risk
@@ -110,6 +113,7 @@ func (c *Veil) Validate() map[string]string {
 	if c.VSOCKPort == 0 {
 		problems["-vsock-port"] = "port must not be 0"
 	}
+	problems = validateTunMTU(problems, c.TunMTU)
 	if c.NDots != nil && (*c.NDots < 0 || *c.NDots > 15) {
 		problems["-dns-ndots"] = "must be between 0 and 15"
 	}

--- a/internal/config/veil_proxy.go
+++ b/internal/config/veil_proxy.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"fmt"
+
+	"github.com/Amnesic-Systems/veil/internal/net/tun"
+)
+
 // VeilProxy represents veil-proxy's configuration.
 type VeilProxy struct {
 	// DNSForwarder enables a forwarding DNS resolver on the host side of
@@ -12,6 +18,9 @@ type VeilProxy struct {
 	// VSOCKPort determines the VSOCK port that veil-proxy will be listening on
 	// for incoming connections from the enclave.
 	VSOCKPort uint32
+
+	// TunMTU is the tunnel interface MTU in bytes. Zero selects the default.
+	TunMTU int
 }
 
 func (c *VeilProxy) Validate() map[string]string {
@@ -20,6 +29,26 @@ func (c *VeilProxy) Validate() map[string]string {
 	if c.VSOCKPort == 0 {
 		problems["-vsock-port"] = "port must not be 0"
 	}
+	problems = validateTunMTU(problems, c.TunMTU)
 
 	return problems
+}
+
+func validateTunMTU(problems map[string]string, mtu int) map[string]string {
+	if mtu != 0 && (mtu < tun.MinMTU || mtu > tun.MaxMTU) {
+		problems["-tun-mtu"] = fmt.Sprintf(
+			"must be between %d and %d",
+			tun.MinMTU,
+			tun.MaxMTU,
+		)
+	}
+	return problems
+}
+
+// TunMTUOrDefault returns the configured tunnel MTU, defaulting when unset.
+func TunMTUOrDefault(mtu int) int {
+	if mtu == 0 {
+		return tun.DefaultMTU
+	}
+	return mtu
 }

--- a/internal/config/veil_proxy_test.go
+++ b/internal/config/veil_proxy_test.go
@@ -22,6 +22,11 @@ func TestVeilProxyConfig(t *testing.T) {
 			name: "valid port",
 			cfg:  &VeilProxy{VSOCKPort: 1},
 		},
+		{
+			name:     "invalid tun mtu",
+			cfg:      &VeilProxy{VSOCKPort: 1, TunMTU: 1},
+			wantErrs: 1,
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/net/proxy/proxy.go
+++ b/internal/net/proxy/proxy.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-
-	"github.com/Amnesic-Systems/veil/internal/net/tun"
 )
 
 const lenBufSize = 2
@@ -18,6 +16,7 @@ const lenBufSize = 2
 func TunToVSOCK(
 	from io.ReadCloser,
 	to io.WriteCloser,
+	mtu int,
 	ch chan error,
 	wg *sync.WaitGroup,
 ) {
@@ -25,7 +24,7 @@ func TunToVSOCK(
 	defer wg.Done()
 	var (
 		err     error
-		sendBuf = make([]byte, lenBufSize+tun.MTU)
+		sendBuf = make([]byte, lenBufSize+mtu)
 		pktBuf  = sendBuf[lenBufSize:]
 	)
 
@@ -55,6 +54,7 @@ func TunToVSOCK(
 func VSOCKToTun(
 	from io.ReadCloser,
 	to io.WriteCloser,
+	mtu int,
 	ch chan error,
 	wg *sync.WaitGroup,
 ) {
@@ -64,7 +64,7 @@ func VSOCKToTun(
 		err       error
 		pktLen    uint16
 		pktLenBuf = make([]byte, lenBufSize)
-		pktBuf    = make([]byte, tun.MTU)
+		pktBuf    = make([]byte, mtu)
 	)
 
 	for {
@@ -74,6 +74,10 @@ func VSOCKToTun(
 			break
 		}
 		pktLen = binary.BigEndian.Uint16(pktLenBuf)
+		if int(pktLen) > mtu {
+			err = fmt.Errorf("packet length %d exceeds mtu %d", pktLen, mtu)
+			break
+		}
 
 		// Read the packet.
 		if _, err = io.ReadFull(from, pktBuf[:pktLen]); err != nil {

--- a/internal/net/proxy/proxy_test.go
+++ b/internal/net/proxy/proxy_test.go
@@ -38,8 +38,8 @@ func TestNettest(t *testing.T) {
 			ch         = make(chan error)
 		)
 		wg.Add(2)
-		go TunToVSOCK(in, fwd1, ch, &wg)
-		go VSOCKToTun(fwd2, out, ch, &wg)
+		go TunToVSOCK(in, fwd1, tun.DefaultMTU, ch, &wg)
+		go VSOCKToTun(fwd2, out, tun.DefaultMTU, ch, &wg)
 		return in, out, func() {}, nil
 	}
 	nettest.TestConn(t, nettest.MakePipe(mkPipe))
@@ -51,7 +51,7 @@ func TestAToB(t *testing.T) {
 		wg           sync.WaitGroup
 		ch           = make(chan error)
 		conn1, conn2 = net.Pipe()
-		sendBuf      = make([]byte, tun.MTU*2)
+		sendBuf      = make([]byte, tun.DefaultMTU*2)
 		recvBuf      = &buffer{
 			Buffer: new(bytes.Buffer),
 		}
@@ -69,8 +69,8 @@ func TestAToB(t *testing.T) {
 	assertEq(t, err, nil)
 
 	wg.Add(2)
-	go TunToVSOCK(io.NopCloser(bytes.NewReader(sendBuf)), conn1, ch, &wg)
-	go VSOCKToTun(conn2, recvBuf, ch, &wg)
+	go TunToVSOCK(io.NopCloser(bytes.NewReader(sendBuf)), conn1, tun.DefaultMTU, ch, &wg)
+	go VSOCKToTun(conn2, recvBuf, tun.DefaultMTU, ch, &wg)
 	wg.Wait()
 
 	assertEq(t, bytes.Equal(

--- a/internal/net/tun/tun.go
+++ b/internal/net/tun/tun.go
@@ -1,8 +1,33 @@
 package tun
 
 const (
-	Name      = "tun0"
-	MTU       = 65535 // The maximum-allowed MTU for the tun interface.
+	Name = "tun0"
+
+	// DefaultMTU is the default tunnel interface MTU. It matches the prior
+	// hardcoded value so existing deployments behave the same without -tun-mtu.
+	DefaultMTU = 65535
+
+	// MinMTU is the smallest supported tunnel MTU.
+	MinMTU = 576
+
+	// MaxMTU is the largest supported tunnel MTU. It matches the largest packet
+	// size that can be framed on the VSOCK tunnel.
+	MaxMTU = 65535
+
 	ProxyIP   = "10.0.0.1"
 	EnclaveIP = "10.0.0.2"
 )
+
+// Config contains tun interface settings shared by veil-proxy and veil-daemon.
+type Config struct {
+	// MTU is the tunnel interface MTU in bytes. Zero selects DefaultMTU.
+	MTU int
+}
+
+// MTUOrDefault returns the configured MTU, or DefaultMTU when unset.
+func (c Config) MTUOrDefault() int {
+	if c.MTU == 0 {
+		return DefaultMTU
+	}
+	return c.MTU
+}

--- a/internal/net/tun/tun_darwin.go
+++ b/internal/net/tun/tun_darwin.go
@@ -7,10 +7,10 @@ import (
 
 var errNotImplemented = errors.New("not implemented on darwin")
 
-func SetupTunAsProxy() (*os.File, error) {
+func SetupTunAsProxy(_ Config) (*os.File, error) {
 	return nil, errNotImplemented
 }
 
-func SetupTunAsEnclave() (*os.File, error) {
+func SetupTunAsEnclave(_ Config) (*os.File, error) {
 	return nil, errNotImplemented
 }

--- a/internal/net/tun/tun_linux.go
+++ b/internal/net/tun/tun_linux.go
@@ -23,24 +23,24 @@ type ifReq struct {
 
 // SetupTunAsProxy sets up a tun interface and returns a ready-to-use file
 // descriptor.
-func SetupTunAsProxy() (*os.File, error) {
-	return setupTun(asProxy)
+func SetupTunAsProxy(cfg Config) (*os.File, error) {
+	return setupTun(asProxy, cfg.MTUOrDefault())
 }
 
 // SetupTunAsEnclave sets up a tun interface and returns a ready-to-use file
 // descriptor.
-func SetupTunAsEnclave() (*os.File, error) {
-	return setupTun(asEnclave)
+func SetupTunAsEnclave(cfg Config) (*os.File, error) {
+	return setupTun(asEnclave, cfg.MTUOrDefault())
 }
 
 // setupTun creates and configures a tun interface. The given typ must be
 // asEnclave or asProxy.
-func setupTun(typ int) (*os.File, error) {
+func setupTun(typ int, mtu int) (*os.File, error) {
 	fd, err := createTun()
 	if err != nil {
 		return nil, err
 	}
-	if err := configureTun(typ); err != nil {
+	if err := configureTun(typ, mtu); err != nil {
 		_ = fd.Close()
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func createTun() (*os.File, error) {
 // configureTun configures our tun device. The function assigns an IP address,
 // sets the link MTU, and may set the default gateway, after which the device
 // is ready for use.
-func configureTun(typ int) error {
+func configureTun(typ int, mtu int) error {
 	cidrStr := ProxyIP + "/24"
 	if typ == asEnclave {
 		cidrStr = EnclaveIP + "/24"
@@ -97,7 +97,7 @@ func configureTun(typ int) error {
 	if err = link.SetLinkIp(cidr, network); err != nil {
 		return fmt.Errorf("failed to set link address: %w", err)
 	}
-	if err := link.SetLinkMTU(MTU); err != nil {
+	if err := link.SetLinkMTU(mtu); err != nil {
 		return fmt.Errorf("failed to set link MTU: %w", err)
 	}
 	// Set the enclave's default gateway to the proxy's IP address.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -69,7 +69,10 @@ func Run(
 
 	// Set up the networking tunnel. This function will block until the tunnel
 	// is ready to use.
-	if err := tunnel.New(ctx, mechanism, cfg.VSOCKPort); err != nil {
+	if err := tunnel.New(ctx, mechanism, tunnel.Settings{
+		Port: cfg.VSOCKPort,
+		MTU:  config.TunMTUOrDefault(cfg.TunMTU),
+	}); err != nil {
 		log.Fatalf("Failed to set up tunnel: %v", err)
 	}
 

--- a/internal/tunnel/noop.go
+++ b/internal/tunnel/noop.go
@@ -8,6 +8,6 @@ func NewNoop() *NoopTunneler {
 	return &NoopTunneler{}
 }
 
-func (t *NoopTunneler) Start(_ context.Context, _ uint32) error {
+func (t *NoopTunneler) Start(_ context.Context, _ Settings) error {
 	return nil
 }

--- a/internal/tunnel/noop_test.go
+++ b/internal/tunnel/noop_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNoopTunneler(t *testing.T) {
-	require.NoError(t, NewNoop().Start(t.Context(), 0))
+	require.NoError(t, NewNoop().Start(t.Context(), Settings{}))
 }

--- a/internal/tunnel/tunneler.go
+++ b/internal/tunnel/tunneler.go
@@ -9,12 +9,21 @@ var (
 	_ Mechanism = (*VsockTunneler)(nil)
 )
 
+// Settings configures a VSOCK tunnel between the enclave and veil-proxy.
+type Settings struct {
+	// Port is the VSOCK port used by the tunnel.
+	Port uint32
+
+	// MTU is the tunnel interface MTU in bytes. Zero selects the default.
+	MTU int
+}
+
 type Mechanism interface {
 	// Start starts the tunneling mechanism and blocks until networking is set up
 	// or the context is canceled before setup completes.
-	Start(ctx context.Context, port uint32) error
+	Start(ctx context.Context, cfg Settings) error
 }
 
-func New(ctx context.Context, m Mechanism, port uint32) error {
-	return m.Start(ctx, port)
+func New(ctx context.Context, m Mechanism, cfg Settings) error {
+	return m.Start(ctx, cfg)
 }

--- a/internal/tunnel/vsock.go
+++ b/internal/tunnel/vsock.go
@@ -33,7 +33,7 @@ func NewVSOCK() *VsockTunneler {
 
 func (v *VsockTunneler) Start(
 	ctx context.Context,
-	port uint32,
+	cfg Settings,
 ) error {
 	readyCh := make(chan struct{})
 	var ready sync.Once
@@ -47,7 +47,7 @@ func (v *VsockTunneler) Start(
 				return
 			}
 
-			if err = setupTunnel(ctx, v.timer, port, func() {
+			if err = setupTunnel(ctx, v.timer, cfg, func() {
 				ready.Do(func() { close(readyCh) })
 			}); err != nil {
 				log.Printf("Error: %v", err)
@@ -70,7 +70,7 @@ func (v *VsockTunneler) Start(
 func setupTunnel(
 	ctx context.Context,
 	timer *backoff.Timer,
-	port uint32,
+	cfg Settings,
 	ready func(),
 ) (err error) {
 	defer errs.Wrap(&err, "tunnel failed")
@@ -80,26 +80,28 @@ func setupTunnel(
 	)
 
 	// Establish TCP-over-VSOCK connection with veil-proxy.
-	conn, err := vsock.Dial(proxyCID, port, nil)
+	conn, err := vsock.Dial(proxyCID, cfg.Port, nil)
 	if err != nil {
 		return fmt.Errorf("failed to connect to veil-proxy: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 	log.Println("Established TCP connection with veil-proxy.")
 
+	mtu := tun.Config{MTU: cfg.MTU}.MTUOrDefault()
+
 	// Create and configure the tun device.
-	tun, err := tun.SetupTunAsEnclave()
+	tunDev, err := tun.SetupTunAsEnclave(tun.Config{MTU: cfg.MTU})
 	if err != nil {
 		return fmt.Errorf("failed to set up tun device: %w", err)
 	}
-	defer func() { _ = tun.Close() }()
+	defer func() { _ = tunDev.Close() }()
 	log.Println("Set up tun device.")
 
 	// Spawn goroutines that forward traffic and wait for them to finish.
 	wg.Add(2)
 	defer wg.Wait()
-	go proxy.VSOCKToTun(conn, tun, errCh, &wg)
-	go proxy.TunToVSOCK(tun, conn, errCh, &wg)
+	go proxy.VSOCKToTun(conn, tunDev, mtu, errCh, &wg)
+	go proxy.TunToVSOCK(tunDev, conn, mtu, errCh, &wg)
 	log.Println("Started goroutines to forward traffic.")
 	ready()
 
@@ -111,7 +113,7 @@ func setupTunnel(
 	case err := <-errCh:
 		return err
 	case <-ctx.Done():
-		_, _ = conn.Close(), tun.Close()
+		_, _ = conn.Close(), tunDev.Close()
 		return nil
 	}
 }

--- a/internal/tunnel/vsock_test.go
+++ b/internal/tunnel/vsock_test.go
@@ -11,5 +11,5 @@ func TestVsockTunneler(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	require.ErrorIs(t, NewVSOCK().Start(ctx, 0), context.Canceled)
+	require.ErrorIs(t, NewVSOCK().Start(ctx, Settings{}), context.Canceled)
 }


### PR DESCRIPTION
Add -tun-mtu to veil-proxy and veil-daemon. The default remains 65535 to preserve existing behavior; both sides must use the same value.