### PR TITLE
Add tests for veil-verify.

### DIFF
--- a/cmd/veil-verify/attestation.go
+++ b/cmd/veil-verify/attestation.go
@@ -66,7 +66,8 @@ func attestEnclave(
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("enclave returned %q with body: %s", resp.Status, string(body))
+		return fmt.Errorf("%w: %q with body: %s",
+			errs.ErrEnclaveErr, resp.Status, string(body))
 	}
 
 	// Parse the attestation document.
@@ -105,7 +106,7 @@ func attestEnclave(
 	if !pcrs.Equal(doc.PCRs) {
 		log.Printf("Expected PCRs:\n%sbut got PCRs:\n%s", pcrs, doc.PCRs)
 		color.Red("Enclave's code DOES NOT match local code!")
-		return errors.New("enclave code does not match local code")
+		return errs.ErrPCRMismatch
 	} else {
 		color.Green("Enclave's code matches local code!")
 		return nil
@@ -123,7 +124,7 @@ func verifyTLSBinding(resp *http.Response, doc *enclave.Document) error {
 	}
 	gotHash := sha256.Sum256(resp.TLS.PeerCertificates[0].Raw)
 	if !bytes.Equal(gotHash[:], hashes.TlsKeyHash[:]) {
-		return errors.New("TLS certificate does not match attestation document")
+		return errs.ErrBindingMismatch
 	}
 	return nil
 }

--- a/cmd/veil-verify/attestation_test.go
+++ b/cmd/veil-verify/attestation_test.go
@@ -1,11 +1,208 @@
 package main
 
 import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/Amnesic-Systems/veil/internal/config"
 	"github.com/Amnesic-Systems/veil/internal/enclave"
+	"github.com/Amnesic-Systems/veil/internal/errs"
+	"github.com/Amnesic-Systems/veil/internal/httpx"
+	"github.com/Amnesic-Systems/veil/internal/nonce"
+	"github.com/Amnesic-Systems/veil/internal/service"
+	"github.com/Amnesic-Systems/veil/internal/service/attestation"
 	"github.com/stretchr/testify/require"
 )
+
+func testPCRs() enclave.PCR {
+	return enclave.PCR{
+		0: []byte(strings.Repeat("a", 48)),
+		1: []byte(strings.Repeat("b", 48)),
+		2: []byte(strings.Repeat("c", 48)),
+	}
+}
+
+func newAttestationServer(
+	t *testing.T,
+	mutate func(*enclave.Document),
+) *httptest.Server {
+	t.Helper()
+
+	var srv *httptest.Server
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != service.PathAttestation {
+			http.NotFound(w, r)
+			return
+		}
+		n, err := httpx.ExtractNonce(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		certHash := sha256.Sum256(srv.Certificate().Raw)
+		doc := &enclave.Document{
+			PCRs: testPCRs(),
+			AuxInfo: enclave.AuxInfo{
+				PublicKey: (&attestation.Hashes{TlsKeyHash: &certHash}).Serialize(),
+				Nonce:     n.ToSlice(),
+			},
+		}
+		if mutate != nil {
+			mutate(doc)
+		}
+
+		docBytes, err := json.Marshal(doc)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rawDoc := enclave.RawDocument{
+			Type: enclave.TypeNoop,
+			Doc:  docBytes,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&rawDoc); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	return srv
+}
+
+func TestBuildReq(t *testing.T) {
+	n := new(nonce.Nonce)
+	req, err := buildReq(t.Context(), "https://example.com/", n)
+	require.NoError(t, err)
+
+	u := req.URL
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "https", u.Scheme)
+	require.Equal(t, "example.com", u.Host)
+	require.Equal(t, service.PathAttestation, u.Path)
+	require.Equal(t, n.B64(), u.Query().Get(httpx.ParamNonce))
+}
+
+func TestAttestEnclave(t *testing.T) {
+	cases := []struct {
+		name      string
+		newServer func(*testing.T) *httptest.Server
+		localPCRs enclave.PCR
+		wantErr   error
+	}{
+		{
+			name: "valid",
+			newServer: func(t *testing.T) *httptest.Server {
+				return newAttestationServer(t, nil)
+			},
+			localPCRs: testPCRs(),
+		},
+		{
+			name: "pcr mismatch",
+			newServer: func(t *testing.T) *httptest.Server {
+				return newAttestationServer(t, nil)
+			},
+			localPCRs: enclave.PCR{0: []byte(strings.Repeat("z", 48))},
+			wantErr:   errs.ErrPCRMismatch,
+		},
+		{
+			name: "tls binding mismatch",
+			newServer: func(t *testing.T) *httptest.Server {
+				return newAttestationServer(t, func(doc *enclave.Document) {
+					otherHash := sha256.Sum256([]byte("other certificate"))
+					doc.PublicKey = (&attestation.Hashes{TlsKeyHash: &otherHash}).Serialize()
+				})
+			},
+			localPCRs: testPCRs(),
+			wantErr:   errs.ErrBindingMismatch,
+		},
+		{
+			name: "missing tls binding",
+			newServer: func(t *testing.T) *httptest.Server {
+				return newAttestationServer(t, func(doc *enclave.Document) {
+					doc.PublicKey = nil
+				})
+			},
+			localPCRs: testPCRs(),
+			wantErr:   errs.ErrIsNil,
+		},
+		{
+			name: "nonce mismatch",
+			newServer: func(t *testing.T) *httptest.Server {
+				return newAttestationServer(t, func(doc *enclave.Document) {
+					doc.Nonce = make([]byte, nonce.Len)
+					doc.Nonce[0] = 1
+				})
+			},
+			localPCRs: testPCRs(),
+			wantErr:   errs.ErrNonceMismatch,
+		},
+		{
+			name: "http error",
+			newServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "nope", http.StatusInternalServerError)
+				}))
+			},
+			localPCRs: testPCRs(),
+			wantErr:   errs.ErrEnclaveErr,
+		},
+		{
+			name: "wrong attestation type",
+			newServer: func(t *testing.T) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					n, err := httpx.ExtractNonce(r)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					docBytes, err := json.Marshal(&enclave.Document{AuxInfo: enclave.AuxInfo{
+						Nonce: n.ToSlice(),
+					}})
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					rawDoc := enclave.RawDocument{Type: enclave.TypeNitro, Doc: docBytes}
+					if err := json.NewEncoder(w).Encode(&rawDoc); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+				}))
+			},
+			localPCRs: testPCRs(),
+			wantErr:   errs.ErrTypeMismatch,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := c.newServer(t)
+			defer srv.Close()
+
+			cfg := &config.VeilVerify{Addr: srv.URL, Testing: true}
+			err := attestEnclave(t.Context(), cfg, c.localPCRs)
+			require.ErrorIs(t, err, c.wantErr)
+		})
+	}
+}
+
+func TestAttestEnclaveCanceledContext(t *testing.T) {
+	srv := newAttestationServer(t, nil)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cfg := &config.VeilVerify{Addr: srv.URL, Testing: true}
+	err := attestEnclave(ctx, cfg, testPCRs())
+	require.ErrorIs(t, err, context.Canceled)
+}
 
 func TestToPCR(t *testing.T) {
 	cases := []struct {
@@ -57,6 +254,62 @@ func TestToPCR(t *testing.T) {
 			gotPCRs, err := toPCR(c.in)
 			require.Equal(t, c.wantErr, err != nil)
 			require.True(t, gotPCRs.Equal(c.wantPCRs))
+		})
+	}
+}
+
+func TestVerifyTLSBinding(t *testing.T) {
+	cert := &x509.Certificate{Raw: []byte("cert")}
+	certHash := sha256.Sum256(cert.Raw)
+	otherHash := sha256.Sum256([]byte("other cert"))
+
+	cases := []struct {
+		name    string
+		resp    *http.Response
+		doc     *enclave.Document
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			resp: &http.Response{TLS: &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			}},
+			doc: &enclave.Document{AuxInfo: enclave.AuxInfo{
+				PublicKey: (&attestation.Hashes{TlsKeyHash: &certHash}).Serialize(),
+			}},
+		},
+		{
+			name: "mismatched certificate",
+			resp: &http.Response{TLS: &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			}},
+			doc: &enclave.Document{AuxInfo: enclave.AuxInfo{
+				PublicKey: (&attestation.Hashes{TlsKeyHash: &otherHash}).Serialize(),
+			}},
+			wantErr: true,
+		},
+		{
+			name: "missing tls state",
+			resp: &http.Response{},
+			doc: &enclave.Document{AuxInfo: enclave.AuxInfo{
+				PublicKey: (&attestation.Hashes{TlsKeyHash: &certHash}).Serialize(),
+			}},
+			wantErr: true,
+		},
+		{
+			name: "missing attested hash",
+			resp: &http.Response{TLS: &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			}},
+			doc:     &enclave.Document{},
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := verifyTLSBinding(c.resp, c.doc)
+			require.Equal(t, c.wantErr, err != nil)
 		})
 	}
 }

--- a/internal/enclave/nitro/attester.go
+++ b/internal/enclave/nitro/attester.go
@@ -73,7 +73,7 @@ func (a *Attester) Verify(
 		return nil, errors.New("attestation document is nil")
 	}
 	if doc.Type != a.Type() {
-		return nil, errors.New("attestation document type mismatch")
+		return nil, errs.ErrTypeMismatch
 	}
 
 	// First, verify the attestation document.
@@ -91,7 +91,7 @@ func (a *Attester) Verify(
 			return nil, err
 		}
 		if *ourNonce != *docNonce {
-			return nil, errors.New("nonce does not match")
+			return nil, errs.ErrNonceMismatch
 		}
 	}
 

--- a/internal/enclave/nitro/attester.go
+++ b/internal/enclave/nitro/attester.go
@@ -2,6 +2,7 @@ package nitro
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Amnesic-Systems/veil/internal/enclave"
@@ -41,7 +42,7 @@ func (a *Attester) Attest(aux *enclave.AuxInfo) (_ *enclave.RawDocument, err err
 	}
 
 	if aux == nil {
-		return nil, errors.New("aux info is nil")
+		return nil, fmt.Errorf("%w: %s", errs.ErrIsNil, "aux info")
 	}
 
 	req := &request.Attestation{

--- a/internal/enclave/noop/attester.go
+++ b/internal/enclave/noop/attester.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/Amnesic-Systems/veil/internal/enclave"
+	"github.com/Amnesic-Systems/veil/internal/errs"
 	"github.com/Amnesic-Systems/veil/internal/nonce"
 )
 
@@ -22,9 +23,10 @@ func (*Attester) Type() string {
 
 func (*Attester) Attest(aux *enclave.AuxInfo) (*enclave.RawDocument, error) {
 	// With the Nitro attester, the attestation document is a CBOR-encoded byte
-	// array.  For simplicity, the Noop attester encodes the given AuxInfo as a
+	// array.  For simplicity, the Noop attester encodes a Document containing the
+	// given AuxInfo as a
 	// JSON object in the attestation document.
-	a, err := json.Marshal(aux)
+	a, err := json.Marshal(&enclave.Document{AuxInfo: *aux})
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +37,22 @@ func (*Attester) Attest(aux *enclave.AuxInfo) (*enclave.RawDocument, error) {
 }
 
 func (*Attester) Verify(a *enclave.RawDocument, n *nonce.Nonce) (*enclave.Document, error) {
-	var doc = new(enclave.Document)
-	var aux = new(enclave.AuxInfo)
+	if a.Type != enclave.TypeNoop {
+		return nil, errs.ErrTypeMismatch
+	}
 
-	if err := json.Unmarshal(a.Doc, aux); err != nil {
+	doc := new(enclave.Document)
+	if err := json.Unmarshal(a.Doc, doc); err != nil {
 		return nil, err
 	}
-	doc.AuxInfo = *aux
+	if n != nil {
+		docNonce, err := nonce.FromSlice(doc.Nonce)
+		if err != nil {
+			return nil, err
+		}
+		if *n != *docNonce {
+			return nil, errs.ErrNonceMismatch
+		}
+	}
 	return doc, nil
 }

--- a/internal/enclave/noop/attester.go
+++ b/internal/enclave/noop/attester.go
@@ -2,6 +2,7 @@ package noop
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/errs"
@@ -22,6 +23,10 @@ func (*Attester) Type() string {
 }
 
 func (*Attester) Attest(aux *enclave.AuxInfo) (*enclave.RawDocument, error) {
+	if aux == nil {
+		return nil, fmt.Errorf("%w: %s", errs.ErrIsNil, "aux info")
+	}
+
 	// With the Nitro attester, the attestation document is a CBOR-encoded byte
 	// array.  For simplicity, the Noop attester encodes a Document containing the
 	// given AuxInfo as a

--- a/internal/enclave/noop/attester_test.go
+++ b/internal/enclave/noop/attester_test.go
@@ -1,10 +1,12 @@
 package noop
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Amnesic-Systems/veil/internal/enclave"
 	"github.com/Amnesic-Systems/veil/internal/nonce"
+	"github.com/Amnesic-Systems/veil/internal/util/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,17 +17,18 @@ func TestType(t *testing.T) {
 func TestSuccessfulVerification(t *testing.T) {
 	var (
 		a       = NewAttester()
+		n       = must.Get(nonce.FromSlice([]byte(strings.Repeat("a", 20))))
 		origAux = enclave.AuxInfo{
 			PublicKey: []byte("abc"),
 			UserData:  []byte("def"),
-			Nonce:     []byte("ghi"),
+			Nonce:     n.ToSlice(),
 		}
 	)
 
 	attestation, err := a.Attest(&origAux)
 	require.Nil(t, err)
 
-	doc, err := a.Verify(attestation, &nonce.Nonce{})
+	doc, err := a.Verify(attestation, n)
 	require.Nil(t, err)
 	require.Equal(t, origAux, doc.AuxInfo)
 }

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -7,9 +7,14 @@ import (
 )
 
 var (
-	ErrInvalidFormat = errors.New("invalid format")
-	ErrInvalidLength = errors.New("invalid length")
-	ErrIsNil         = errors.New("argument must not be nil")
+	ErrInvalidFormat   = errors.New("invalid format")
+	ErrInvalidLength   = errors.New("invalid length")
+	ErrIsNil           = errors.New("argument must not be nil")
+	ErrPCRMismatch     = errors.New("enclave code does not match local code")
+	ErrBindingMismatch = errors.New("TLS certificate does not match attestation document")
+	ErrNonceMismatch   = errors.New("nonce does not match")
+	ErrTypeMismatch    = errors.New("attestation document type mismatch")
+	ErrEnclaveErr      = errors.New("enclave returned an error")
 )
 
 // Wrap wraps the given error using the given string and (if provided) string


### PR DESCRIPTION
So far, veil-verify has received very little attention. This PR adds a number of tests; mostly for the critical `attestEnclave` function.

This PR fixes https://github.com/Amnesic-Systems/veil/issues/15.