### PR TITLE
Don't delete PCR4 from maps.

### DIFF
--- a/internal/enclave/pcr.go
+++ b/internal/enclave/pcr.go
@@ -34,18 +34,17 @@ func (p PCR) String() string {
 }
 
 // Equal returns true if (and only if) the two given PCR maps are identical.
+// Note that this function ignores PCR4 because it contains a hash over the
+// parent's instance ID, which is only known at runtime. We ignore it for now.
 func (ours PCR) Equal(theirs PCR) bool {
-	// PCR4 contains a hash over the parent's instance ID, which is known at
-	// runtime.  We ignore it for now, until we have a better solution for how
-	// to handle this.
-	delete(ours, 4)
-	delete(theirs, 4)
-
-	if len(ours) != len(theirs) {
+	if pcrLen(ours) != pcrLen(theirs) {
 		return false
 	}
 
 	for i, ourValue := range ours {
+		if i == 4 {
+			continue
+		}
 		theirValue, exists := theirs[i]
 		if !exists {
 			return false
@@ -55,4 +54,12 @@ func (ours PCR) Equal(theirs PCR) bool {
 		}
 	}
 	return true
+}
+
+func pcrLen(p PCR) int {
+	n := len(p)
+	if _, ok := p[4]; ok {
+		n--
+	}
+	return n
 }

--- a/internal/enclave/pcr_test.go
+++ b/internal/enclave/pcr_test.go
@@ -91,6 +91,17 @@ func TestPCRsEqual(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "ignore PCR4 if only set once",
+			pcr1: PCR{
+				1: []byte("foo"),
+				4: []byte("bar"),
+			},
+			pcr2: PCR{
+				1: []byte("foo"),
+			},
+			want: true,
+		},
+		{
 			name: "length mismatch",
 			pcr1: PCR{
 				1: []byte("foobar"),
@@ -100,17 +111,6 @@ func TestPCRsEqual(t *testing.T) {
 				1: []byte("foobar"),
 			},
 			want: false,
-		},
-		{
-			name: "length mismatch due to PCR4",
-			pcr1: PCR{
-				1: []byte("foo"),
-				4: []byte("bar"),
-			},
-			pcr2: PCR{
-				1: []byte("foo"),
-			},
-			want: true,
 		},
 		{
 			name: "PCR index mismatch",


### PR DESCRIPTION
So far, the code would delete PCR4 from the given maps. That worked because we have been ignoring PCR4 but it's a dirty hack. This PR changes `Equal` to not modify the given maps.